### PR TITLE
"use-package :load-path" should accept function calls

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -389,12 +389,12 @@
          ,@(mapcar
             #'(lambda (path)
                 `(add-to-list 'load-path
-                              ,(if (file-name-absolute-p path)
-                                   path
-                                 (expand-file-name path user-emacs-directory))))
-            (if (stringp pkg-load-path)
-                (list pkg-load-path)
-              pkg-load-path))
+                              (if (file-name-absolute-p ,path)
+                                   ,path
+                                 (expand-file-name ,path user-emacs-directory))))
+            (cond 
+	     ((not (null pkg-load-path)) `(,pkg-load-path))
+	     (t nil)))
 
          (when byte-compile-current-file
            ,@defines-eval


### PR DESCRIPTION
It's handy instead of hardcoded string put function call for load-path, for example:

``` lisp
(use-package monky
  :load-path (expand-site-lisp "monky"))
```

I've made some dirty change, but not sure if it fits to ELisp bect practices - I'm not very good with macro...
