### PR TITLE
Better support for ELPA.

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -369,12 +369,17 @@ For full documentation. please see commentary.
          (name-string (if (stringp name) name (symbol-name name)))
          (name-symbol (if (stringp name) (intern name) name)))
 
+    ;; force this immediately -- one off cost
     (unless (plist-get args :disabled)
-      
-      ;; force this immediately -- one off cost!
-      (if (plist-get args :ensure)
-          (use-package-ensure-elpa name))
-      
+      (let* ((ensure (plist-get args :ensure))
+             (package-name 
+              (or (and (eq ensure t)
+                       name)
+                  ensure)))
+      (when package-name 
+        (use-package-ensure-elpa package-name)))
+ 	  	
+
       (if diminish-var
           (setq config-body
                 `(progn


### PR DESCRIPTION
Some packages such as ECB already provide an autoload file,
so it is this that use-package needs to require. However,
the ELPA name is ecb. This commit allows ensure to take an
argument (other than t).
