### PR TITLE
Macroexpand quoted eval-after-load block early

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -461,10 +461,12 @@
                    ,init-body
                    ,(unless (null config-body)
                       `(eval-after-load ,name-string
-                         '(if ,requires-test
-                              (with-elapsed-timer
-                                  ,(format "Configuring package %s" name-string)
-                                ,config-body))))
+                         (quote
+                           (if ,requires-test
+                               ,(macroexpand-all
+                                  `(with-elapsed-timer
+                                       ,(format "Configuring package %s" name-string)
+                                     ,config-body))))))
                    t))
             `(if (and ,(or predicate t)
                       ,requires-test)


### PR DESCRIPTION
The main `use-package' macro incorrectly planted code containing a call to the`with-elapsed-timer' macro in a quoted block to be run by `eval-after-load'. If package use-package was not loaded at runtime, the block would error saying correctly that`with-elapsed-timer' is undefined. This mod correctly macroexpands the block at code generation time.
