### PR TITLE
Macro expansion redux

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -311,7 +311,7 @@
        ,(when use-package-verbose
           `(let ((elapsed
                   (float-time (time-subtract (current-time) now))))
-             (if (> elapsed use-package-minimum-reported-time)
+             (if (> elapsed ,use-package-minimum-reported-time)
                  (message "%s...done (%.3fs)" ,text elapsed)
                (message "%s...done" ,text)))))))
 


### PR DESCRIPTION
Tweak to previous fix for expanding macros correctly at code-planting time. Specifically, eval `use-package-minimum-reported-time' at code-planting time not at runtime (which would require use-package.el to be loaded first).
