### PR TITLE
package header should be the full filename + ext

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -1,4 +1,4 @@
-;;; use-package --- A use-package declaration for simplifying your .emacs
+;;; use-package.el --- A use-package declaration for simplifying your .emacs
 
 ;; Copyright (C) 2012 John Wiegley
 


### PR DESCRIPTION
this fixes a bug in using `(package-buffer-info)`

Right now MELPA ignores the dependencies in this package; failing
gracefully which maybe it shouldn't.
