### PR TITLE
refine use-package highlighting regexp

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -660,7 +660,7 @@ For full documentation. please see commentary.
 (put 'use-package 'lisp-indent-function 1)
 
 (defconst use-package-font-lock-keywords
-  '(("(\\(use-package\\)\\> *\\(\\sw+\\)?"
+  '(("(\\(use-package\\)\\_>[\n[:space:]]+\\(\\(?:\\s_\\|\\sw\\)+\\)"
      (1 font-lock-keyword-face)
      (2 font-lock-constant-face))))
 


### PR DESCRIPTION
it wasn't highlight the `bar` in `(use-package foo-bar ...)`, and it was highlighting `(use-package-init-on-idle ...)`
