### PR TITLE
Improve (describe-personal-keybindings) output

### DIFF
--- a/bind-key.el
+++ b/bind-key.el
@@ -170,10 +170,10 @@
       (cons (string< (caar l) (caar r)) nil)))))
 
 (defun describe-personal-keybindings ()
+  "Display all the personal keybindings defined by `bind-key'."
   (interactive)
-  (with-current-buffer (get-buffer-create "*Personal Keybindings*")
-    (delete-region (point-min) (point-max))
-    (insert "Key name          Command                                 Comments
+  (with-output-to-temp-buffer "*Personal Keybindings*"
+    (princ "Key name          Command                                 Comments
 ----------------- --------------------------------------- ---------------------
 ")
     (let (last-binding)
@@ -184,12 +184,12 @@
                                (car (compare-keybindings l r))))))
 
         (if (not (eq (cdar last-binding) (cdar binding)))
-            (insert ?\n (format "\n%s\n%s\n\n"
-                                (cdar binding)
-                                (make-string 79 ?-)))
+            (princ (format "\n\n%s\n%s\n\n"
+                           (cdar binding)
+                           (make-string 79 ?-)))
           (if (and last-binding
                    (cdr (compare-keybindings last-binding binding)))
-              (insert ?\n)))
+              (princ "\n")))
 
         (let* ((key-name (caar binding))
                (at-present (lookup-key (or (symbol-value (cdar binding))
@@ -202,10 +202,10 @@
                                       (get-binding-description was-command)))
                (at-present-desc (get-binding-description at-present))
                )
-          (insert
+          (princ
            (format
             "%-18s%-40s%s\n"
-            key-name command-desc
+            key-name (format "`%s\'" command-desc)
             (if (string= command-desc at-present-desc)
                 (if (or (null was-command)
                         (string= command-desc was-command-desc))
@@ -213,10 +213,7 @@
                   (format "(%s)" was-command-desc))
               (format "[now: %s]" at-present)))))
 
-        (setq last-binding binding)))
-
-    (goto-char (point-min))
-    (display-buffer (current-buffer))))
+        (setq last-binding binding)))))
 
 (provide 'bind-key)
 ;; Local Variables:


### PR DESCRIPTION
Create *Personal Keybindings* by with-output-to-temp-buffer. It
redirects standard output to the buffer and display it in help mode. So
we can get help mode keybindings such as "q" for free.

Quote the command-desc output so that it is made into a hyperlink.
