### PR TITLE
Fix highlight use-package for Emacs snapshot

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -661,7 +661,7 @@ For full documentation. please see commentary.
 (put 'use-package 'lisp-indent-function 1)
 
 (defconst use-package-font-lock-keywords
-  '(("(\\(use-package\\)\\_>[ \t']*\\(\\sw+\\)?"
+  '(("(\\(use-package\\)\\_>[ \t']*\\(\\(?:\\sw\\|\\s_\\)+\\)?"
      (1 font-lock-keyword-face)
      (2 font-lock-constant-face nil t))))
 


### PR DESCRIPTION
The commit a5edc94 fixed the highlight by following the regexp as for
require. However in Emacs truck, it only highlights first part of the
package name.

This change follows the regexp for require on emacs truck. See line
2327 on font-lock.el in the following patch.
http://bzr.savannah.gnu.org/lh/emacs/trunk/revision/111821
