### PR TITLE
pass name (not name-string) to eval-after-load

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -637,7 +637,7 @@ For full documentation. please see commentary.
                    ,@form
                    ,init-body
                    ,(unless (null config-body)
-                      `(eval-after-load ,name-string
+                      `(eval-after-load ,(if (stringp name) name `',name)
                          `(,(lambda ()
                               (if ,requires-test
                                   ,(macroexpand-all


### PR DESCRIPTION
Fixes #52: the :config block would be triggered when loading a config
file with the same name as the package and again when loading the
package itself.
