### PR TITLE
Properly enable runtime dependency for :idle stanza (issue #60)

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -542,6 +542,7 @@ For full documentation. please see commentary.
       (when idle-body
         (setq init-body
               `(progn
+                 (require 'use-package)
                  (use-package-init-on-idle (lambda () ,idle-body))
                    ,init-body)))
 


### PR DESCRIPTION
See issue #60.
