### PR TITLE
Add :pre-load to use-package-keywords

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -419,6 +419,7 @@
      :load-path
      :mode
      :pre-init
+     :pre-load
      :requires
   )
   "Keywords recognized by `use-package'.")


### PR DESCRIPTION
The :pre-load keyword cannot be used unless it is in
`use-package-keywords' list.
