### PR TITLE
Backward compatibility with emacs-22.1

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -261,7 +261,8 @@
 (require 'bytecomp)
 (require 'diminish nil t)
 
-(declare-function package-installed-p 'package)
+(when fboundp 'declare-function
+  (declare-function package-installed-p 'package))
 
 (defgroup use-package nil
   "A use-package declaration for simplifying your `.emacs'."


### PR DESCRIPTION
This change supports the emacs that ships with MacOS X, the last version not encumbered by GPLv3.
