### PR TITLE
use-package: use defun as lisp-indent-function

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -574,7 +574,7 @@ For full documentation. please see commentary.
                      ,config-body
                      t))))))))
 
-(put 'use-package 'lisp-indent-function 1)
+(put 'use-package 'lisp-indent-function 'defun)
 
 (defconst use-package-font-lock-keywords
   '(("(\\(use-package\\)\\_>[ \t']*\\(\\(?:\\sw\\|\\s_\\)+\\)?"


### PR DESCRIPTION
When `use-package` is called with only one keyword it is useful to
write:

```
(use-package foo :init
  (progn
    ... long lines ...))
```

instead of

```
(use-package foo
  :init (progn
      ... *too* long lines ...))
```

or

```
(use-package foo
  :init
  (progn
    ... long lines ...))
```

Even when there are multiple keywords or when one never wants to format
the calls to `use-package` as in the first example the use of `defun`
does not really pose a problem.
