### PR TITLE
hyperlink functions in Comments column

### DIFF
--- a/bind-key.el
+++ b/bind-key.el
@@ -205,8 +205,8 @@
                 (if (or (null was-command)
                         (string= command-desc was-command-desc))
                     ""
-                  (format "(%s)" was-command-desc))
-              (format "[now: %s]" at-present)))))
+                  (format "was `%s\'" was-command-desc))
+              (format "[now: `%s\']" at-present)))))
 
         (setq last-binding binding)))))
 


### PR DESCRIPTION
Previously, only the functions in the Command column were hyper-linked. Also
clarify the meaning of the "was" entries in the Comments column.
