### PR TITLE
use-package-with-elapsed-timer: respect option at runtime

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -404,7 +404,7 @@ For full documentation. please see commentary.
 (put 'use-package 'lisp-indent-function 'defun)
 
 (defconst use-package-font-lock-keywords
-  '(("(\\(use-package\\)\\_>[ \t']*\\(\\(?:\\sw\\|\\s_\\)+\\)?"
+  '(("(\\(use-package\\(?:-with-elapsed-timer\\)?\\)\\_>[ \t']*\\(\\(?:\\sw\\|\\s_\\)+\\)?"
      (1 font-lock-keyword-face)
      (2 font-lock-constant-face nil t))))
 


### PR DESCRIPTION
Previously the option `use-package-verbose` was consulted at macro
expansion time, and as a result customizing the option did nothing,
without also recompiling `use-package.el`.

The other two commits are cosmetics.
