### PR TITLE
Add new option use-package-idle-interval.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,14 @@ In this case, I want to autoload the command `haskell-mode` from
 loaded, but wait until after I've opened a Haskell file before loading
 "inf-haskell.el" and "hs-lint.el".
 
-Another similar option to `:init` is `:idle`. Like `:init` this always run,
-however, it does so when Emacs is idle at some time in the future after
-load. This is particularly useful for convienience minor modes which can be
-slow to load. For instance, in this case, I want Emacs to always use
-`global-pabbrev-mode`. `:commands` creates an appropriate autoload; `:idle`
-will run this command at some point in the future. If you start Emacs and
-begin typing straight away, loading will happen eventually.
+Another similar option to `:init` is `:idle`. Like `:init` this always
+run, however, it does so when Emacs is idle at some time in the future
+(see variable `use-package-idle-interval`) after load. This is
+particularly useful for convienience minor modes which can be slow to
+load. For instance, in this case, I want Emacs to always use
+`global-pabbrev-mode`. `:commands` creates an appropriate autoload;
+`:idle` will run this command at some point in the future. If you start
+Emacs and begin typing straight away, loading will happen eventually.
 
     (use-package pabbrev
       :commands global-pabbrev-mode

--- a/use-package.el
+++ b/use-package.el
@@ -58,6 +58,11 @@
   :type 'number
   :group 'use-package)
 
+(defcustom use-package-idle-interval 3
+  "Time to wait when using :idle in a `use-package' specification."
+  :type 'number
+  :group 'use-package)
+
 (defmacro use-package-with-elapsed-timer (text &rest body)
   (declare (indent 1))
   (let ((nowvar (make-symbol "now")))
@@ -82,7 +87,7 @@
   (unless use-package-idle-timer
     (setq use-package-idle-timer
           (run-with-idle-timer
-           3 t
+           use-package-idle-interval t
            'use-package-idle-eval))))
 
 (defun use-package-init-on-idle (form priority)
@@ -129,7 +134,7 @@ Return nil when the queue is empty."
               "Failure on use-package idle. Form: %s, Error: %s"
               next e)))
           ;; recurse after a bit
-          (when (sit-for 3)
+          (when (sit-for use-package-idle-interval)
             (use-package-idle-eval)))
       ;; finished (so far!)
       (cancel-timer use-package-idle-timer)


### PR DESCRIPTION
- use-package.el (use-package-idle-interval): new defcustom
  (use-package-start-idle-timer): use it
  (use-package-idle-eval): use it
- README.md: document it

This addresses bug #77 (thanks Silex for suggesting and testing)
