### PR TITLE
 bind-keys: bind directly to prefix-map

### DIFF
--- a/bind-key.el
+++ b/bind-key.el
@@ -189,11 +189,9 @@ function symbol (unquoted)."
              ,@(when doc `((put ',prefix-map 'variable-documentation ,doc)))
              (define-prefix-command ',prefix-map)
              (bind-key ,prefix ',prefix-map ,map)))
-       ,@(mapcar (lambda (form) `(bind-key ,(if prefix
-                                                (concat prefix " " (car form))
-                                              (car form))
-                                           ',(cdr form)
-                                           ,map))
+       ,@(mapcar (lambda (form)
+                   `(bind-key ,(car form) ',(cdr form)
+                              ,(or prefix-map map)))
                  key-bindings))))
 
 (defun get-binding-description (elem)


### PR DESCRIPTION
instead of constructing equivalent key sequence by string concatenation.
This allows specifying vector key sequences, as in bind-key (since
aed85970814b6a3efd4c86f84041bf3214a8fc82).

fixes #100
