### PR TITLE
* bind-key.el (bind-key): don't eval key-name at macro expansion time.

### DIFF
--- a/bind-key.el
+++ b/bind-key.el
@@ -132,7 +132,7 @@ spelled-out keystrokes, e.g., \"C-c C-z\". See documentation of
         (keyvar (make-symbol "key"))
         (bindingvar (make-symbol "binding"))
         (entryvar (make-symbol "entry")))
-    `(let* ((,namevar ,(eval key-name))
+    `(let* ((,namevar ,key-name)
             (,keyvar (if (vectorp ,namevar) ,namevar
                        (read-kbd-macro ,namevar)))
             (,bindingvar (lookup-key (or ,keymap global-map)


### PR DESCRIPTION
I did something along the lines of

``` emacs-lisp
(dolist (i (list "RET" "SPC" "{" "["))
   (bind-key i #'mycommand somekey-map))
```

and got an error that 'i' was undefined. This PR is to fix that problem.
