### PR TITLE
Don't abort compiling package loading fails

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -402,9 +402,10 @@ For full documentation. please see commentary.
          (eval-when-compile
            (when (bound-and-true-p byte-compile-current-file)
              ,@defines-eval
-             ,(if (stringp name)
-                  `(load ,name t)
-                `(require ',name nil t))))
+             (with-demoted-errors
+                ,(if (stringp name)
+                     `(load ,name t)
+                   `(require ',name nil t)))))
 
          ,(if (and (or commands (use-package-plist-get args :defer))
                    (not (use-package-plist-get args :demand)))


### PR DESCRIPTION
I would like my init.el to compile even of there are problems elsewhere. (?)
