### PR TITLE
assume the declare-function macro exists

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -41,8 +41,7 @@
 (require 'bytecomp)
 (require 'diminish nil t)
 
-(when (fboundp 'declare-function)
-  (declare-function package-installed-p 'package))
+(declare-function package-installed-p 'package)
 
 (defgroup use-package nil
   "A use-package declaration for simplifying your `.emacs'."


### PR DESCRIPTION
Since `declare-function` was added in Emacs 23.1 (five years ago), we
don't need to assert that it is defined.  If the assertion was without
any problems there would be no harm in keeping it, but unfortunately it
causes a compile warning.  Because `declare-function` is a macro with
always expands to `nil` the value of `(fboundp 'declare-function)` ends
up being unused.
