### PR TITLE
Check if an archive is valid when pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,12 +290,24 @@ versioning (> evil-20141208.623 evil-1.0.9) so even if you are
 tracking only a single package from melpa, you will need to tag all
 the non-melpa packages with the appropriate archive.
 
+If you want to manually keep a package updated and ignore upstream
+updates, you can pin it to "manual" which as long as there is no
+repository by that name will Just Work(tm).
+
+`use-package` will throw an error if you try to pin a package to an
+archive that has not been configured via `package-archives` (apart
+from the magic "manual" archive mentioned above):
+
+```
+Archive 'foo' requested for package 'bar' is not available.
+```
+
 Example:
 
 ``` elisp
 (use-package company
   :ensure t
-  :pin "melpa-stable")
+  :pin melpa-stable)
 
 (use-package evil
   :ensure t)
@@ -306,7 +318,12 @@ Example:
   ;; as this package is available only in the gnu archive, this is
   ;; technically not needed, but it helps to highlight where it
   ;; comes from
-  :pin "gnu")
+  :pin gnu)
+
+(use-package org
+  :ensure t
+  ;; ignore org-mode from upstream and use a manually installed version
+  :pin manual)
 ```
 
 NOTE: the :pin argument has no effect on emacs versions < 24.4.


### PR DESCRIPTION
Thanks for merging #136.

I managed to include 2 things in 1 PR - my apologies.

https://github.com/peterhoeg/use-package/commit/c4ab871313b1809f73c2f9179bed0c0f9ba92ca2 has no code changes - it's just emacs re-indenting the code.

https://github.com/peterhoeg/use-package/commit/4f55a08a8c2c51f62bb6f522663d65bc6e5a3d30 adds support for:
- the archive specified when pinning no longer has to be a string (looks a little more like the rest of use-package)
- use-package will now throw an error if the archive that the user tries to pin to has not been configured
- a "manual" archive for those packages that are manually updated

I can absolutely break it into 2 separate PRs if @jwiegley prefers.
