### PR TITLE
Eval the argument to :disable

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -358,7 +358,7 @@ For full documentation. please see commentary.
          (name-symbol (if (stringp name) (intern name) name)))
 
     ;; force this immediately -- one off cost
-    (unless (use-package-plist-get args :disabled)
+    (unless (eval (use-package-plist-get args :disabled))
 
       (when archive-name
         (use-package-pin-package name archive-name))


### PR DESCRIPTION
This allows disabling a package conditionally, e.g.:

    (use-package smex
      :disable (< emacs-major-version 24)
      :ensure t
      ...)

or

    (use-package paradox
      :disable (version< emacs-version "24.4")
      :ensure t
      ...)

It might be nice to have a feature of use-package that gracefully dealt with packages that can't be installed, but this allows fairly general logic to be used when disabling a package.