### PR TITLE
use-package-expand: use display-warning

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -282,9 +282,12 @@ then the expanded macros do their job silently."
 (defsubst use-package-expand (name label form)
   (declare (indent 1))
   (and form
-       `(with-demoted-errors
-            ,(format "Failure in %s of %s: %%S" label name)
-          ,form)))
+       (let ((err (make-symbol "err"))
+             (fmt (format "Failure in %s of %s: %%S" label name)))
+         `(condition-case-unless-debug ,err
+              ,form
+            (error (display-warning 'use-package (format ,fmt ,err) :error)
+                   nil)))))
 
 (defun use--package (name-symbol name-string args)
   "See docstring for `use-package'."


### PR DESCRIPTION
#### Before: 
`*Messages*` contains
```
For information about GNU Emacs and the GNU system, type C-h C-a.
Failure in :init of bind-key: (wrong-type-argument sequencep 1)
use-package ok
```

#### After:
`*Warnings*` buffer **pops up** with
```
Error (use-package): Failure in :init of bind-key: (wrong-type-argument sequencep 1)
```
`*Messages*` contains
```
For information about GNU Emacs and the GNU system, type C-h C-a.
use-package ok
```

---

Tested with `emacs -Q -L . -l ck.el`, where `ck.el` contains

```elisp
(require 'use-package)

(use-package bind-key
  :init (progn (length 1) (message "bind-key ok")))

(use-package use-package
  :init (message "use-package ok"))
```