### PR TITLE
Update README.md, :pin now need a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Example:
 ``` elisp
 (use-package company
   :ensure t
-  :pin melpa-stable)
+  :pin "melpa-stable")
 
 (use-package evil
   :ensure t)
@@ -362,12 +362,12 @@ Example:
   ;; as this package is available only in the gnu archive, this is
   ;; technically not needed, but it helps to highlight where it
   ;; comes from
-  :pin gnu)
+  :pin "gnu")
 
 (use-package org
   :ensure t
   ;; ignore org-mode from upstream and use a manually installed version
-  :pin manual)
+  :pin "manual")
 ```
 
 **NOTE**: the `:pin` argument has no effect on emacs versions < 24.4.


### PR DESCRIPTION
Since 2.0 `:pin` need the archive name as a string.