### PR TITLE
use--package: eval-after-load name

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -336,7 +336,7 @@ the user specified.")
           (ignore
            (display-warning 'use-package (format ,fmt ,err) :error)))))))
 
-(defun use--package (name-symbol name-string args)
+(defun use--package (name name-symbol name-string args)
   "See docstring for `use-package'."
   (let*
       ((commands (plist-get args :commands))
@@ -431,7 +431,7 @@ the user specified.")
                         ,(format "Configuring package %s"
                                  name-string)
                         ,@config-body)))
-                (list `(eval-after-load ,name-string
+                (list `(eval-after-load ',name
                          ',body)))))
        `((use-package-with-elapsed-timer
            ,(format "Loading package %s" name-string)
@@ -522,7 +522,7 @@ this file.  Usage:
       ;; At this point, we can expand the macro using the helper function.
       ;; `use--package'.
       (let*
-          ((body (use--package name-symbol name-string args*))
+          ((body (use--package name name-symbol name-symbol args*))
            (pred (plist-get args* :if))
            (expansion (if pred
                           `(when ,pred ,@body)


### PR DESCRIPTION
instead of name-string. This prevents triggering by config file names
that have the same name as the package.

Reprise of #53.
Fixes #167.