### PR TITLE
get-binding-description: return keymap symbol

### DIFF
--- a/bind-key.el
+++ b/bind-key.el
@@ -234,12 +234,9 @@ function symbol (unquoted)."
       "#<keymap>")
      (t
       elem)))
-   ((keymapp elem)
-    (if (and bind-key-describe-special-forms
-             (symbolp elem)
-             (get elem 'variable-documentation))
-        (format "%s" (get elem 'variable-documentation))
-      "#<keymap>"))
+   ;; must be a symbol, non-symbol keymap case covered above
+   ((and bind-key-describe-special-forms (keymapp elem))
+    (get elem 'variable-documentation))
    ((symbolp elem)
     elem)
    (t


### PR DESCRIPTION
instead of `"#<keymap>"`.

#### Before

```
Key name          Command                                 Comments
----------------- --------------------------------------- ---------------------
C-x p             `#<keymap>'


projectile-rails-mode-goto-map
-------------------------------------------------------------------------------

m                 `projectile-rails-find-current-model'
```

#### After

```
Key name          Command                                 Comments
----------------- --------------------------------------- ---------------------
C-x p             `projectile-rails-mode-goto-map'


projectile-rails-mode-goto-map
-------------------------------------------------------------------------------

m                 `projectile-rails-find-current-model'
```
---

Tested with
```elisp
(require 'bind-key)

(bind-keys :prefix-map projectile-rails-mode-goto-map
           :prefix "C-x p"
           ("m" . projectile-rails-find-current-model))

(describe-personal-keybindings)
```

fixes #113.