### PR TITLE
Enhance :delight with possible values string or t

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -933,9 +933,14 @@ deferred until the prefix key sequence is pressed."
 (defun use-package-normalize/:delight (name-symbol keyword args)
   "Normalize arguments to delight."
   (cond
-   ((and (= (length args) 1)
-         (symbolp (car args)))
-    (list (car args) nil name-symbol))
+   ((= (length args) 1)
+    (cond
+     ((eq (car args) t)
+      (list (intern (concat (symbol-name name-symbol) "-mode")) nil name-symbol))
+     ((stringp (car args) )
+      (list (intern (concat (symbol-name name-symbol) "-mode")) (car args) name-symbol))
+     ((symbolp (car args))
+      (list (car args) nil name-symbol))))
    ((and (= (length args) 2)
          (symbolp (car args)))
     (list (car args) (cadr args) name-symbol))
@@ -943,7 +948,7 @@ deferred until the prefix key sequence is pressed."
          (symbolp (car args)))
     args)
    (t
-    (use-package-error ":delight expects same args as delight function"))))
+    (use-package-error ":delight expects same args as delight function, or only a single string or t"))))
 
 (defun use-package-handler/:delight (name-symbol keyword args rest state)
   (let ((body (use-package-process-keywords name-symbol rest state)))


### PR DESCRIPTION
Enhances #189.

We now should have

    (use-package my-package
     :delight "rep")

to mean `(delight 'my-package-mode "rep" 'my-package)`, and

     :delight t

to mean `(delight 'my-package-mode nil 'my-package)`. I copied some of the logic from :diminish.

Testing this quickly, I didn't stumble on any problems but it would be great if both @jwigley and @darkfeline could have a look so I didn't miss out anything important from your first implementation.