### PR TITLE
Refresh package.el archives if package is missing.

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -434,9 +434,14 @@ manually updated package."
            (concat ":ensure wants an optional package name "
                    "(an unquoted symbol name)")))))))
 
-(defun use-package-ensure-elpa (package)
-  (when (not (package-installed-p package))
-    (package-install package)))
+(defun use-package-ensure-elpa (package &optional no-refresh)
+  (if (package-installed-p package)
+      t
+    (if (or (assoc package package-archive-contents) no-refresh)
+        (package-install package)
+      (progn
+        (package-refresh-contents)
+        (use-package-ensure-elpa package t)))))
 
 (defun use-package-handler/:ensure (name-symbol keyword ensure rest state)
   (let ((body (use-package-process-keywords name-symbol rest state)))


### PR DESCRIPTION
solves #154  (which is closed).. 

I stole this snippet from Steve Purcell since I stumbled upon it when searching for something else...

https://github.com/purcell/emacs.d/blob/master/lisp/init-elpa.el#L48