### PR TITLE
Fix :config loading when package name is a file path

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -874,7 +874,7 @@ deferred until the prefix key sequence is pressed."
                (list t))))))
     (if (plist-get state :deferred)
         (unless (or (null config-body) (equal config-body '(t)))
-          `((eval-after-load ',name-symbol
+          `((eval-after-load ',(intern (file-name-base (symbol-name name-symbol)))
               ',(macroexp-progn config-body))))
       (use-package--with-elapsed-timer
           (format "Loading package %s" name-symbol)


### PR DESCRIPTION
Hello,

Currently when a file is specified as package name, the `:config` block won't load. This patch fixes the issue. This is useful to load a development package without messing with `load-path`.

```lisp
(use-package ~/dir/my-package/lisp/my-package.el
  ...)
```