### PR TITLE
Fix "function might not be defined at runtime" warning

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -882,7 +882,7 @@ deferred until the prefix key sequence is pressed."
             (use-package-concat
              (list `(require ',name-symbol))
              config-body)
-          `((if (not (require ',name-symbol nil t))
+          `((if (not (eval-and-compile (require ',name-symbol nil t)))
                 (ignore
                  (message (format "Could not load %s" ',name-symbol)))
               ,@config-body)))))))


### PR DESCRIPTION
Hi John,

Thank you very much for this wonderful package. I just fixed a bug, let's use a simple example where foo.el is defined as:

    (require 'use-package)
    (use-package foo-lib :config (foo-lib-command))

and foo-lib.el:

    (defun foo-lib-command ())
    (provide 'foo-lib)

When byte-compiling foo.el, the compiler always produces the warning `function foo-lib-command might not be defined at runtime`.

I think the reason is because in the expanded code, the `(require foo-lib)` is nested in a `if` block preventing the compiler from evaluating it at compile time:

    (if (not (require 'foo-lib))
        ...
      )

The solution is to force the compiler evaluate the `(require 'foo-lib)` by enclosing it inside `eval-and-compile`:

    (if (not (eval-and-compile (require 'foo-lib)))
        ...
      )

York
