### PR TITLE
Handle the case when keymap has a broken documentation

### DIFF
--- a/bind-key.el
+++ b/bind-key.el
@@ -256,7 +256,8 @@ function symbol (unquoted)."
       elem)))
    ;; must be a symbol, non-symbol keymap case covered above
    ((and bind-key-describe-special-forms (keymapp elem))
-    (get elem 'variable-documentation))
+    (let ((doc (get elem 'variable-documentation)))
+      (if (stringp doc) doc elem)))
    ((symbolp elem)
     elem)
    (t


### PR DESCRIPTION
Currently there may be issues if a keymap contains an improper
documentation and `bind-key-describe-special-forms` is set to `t`.

- Example 1

Bind "M-o" (which is bound to `facemenu-keymap` by default) to anything:

```elisp
(bind-key "M-o" 'backward-word)
```

Now `M-x describe-personal-keybindings` gives an error:

    Wrong type argument: stringp, 2283076

This happens because `(get-binding-description 'facemenu-keymap)`
evaluates to 2283076.

- Example 2

Make an undocumented map:

```elisp
(bind-keys
 :prefix-map dummy-map
 :prefix "M-z"
 ("b" . backward-char)
 ("f" . forward-char))
```

Now `M-x describe-personal-keybindings` gives a not-very-useful `nil`:

    M-z               `nil'                                   was `zap-to-char'

So what about some modification in `get-binding-description` function to
avoid such issues?

