### PR TITLE
Support :bind (:map '(...)).

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -629,11 +629,13 @@ manually updated package."
    ((use-package-is-sympair arg allow-vector)
     (list arg))
    ((and (not recursed) (listp arg) (listp (cdr arg)))
-    (mapcar #'(lambda (x) (car (use-package-normalize-pairs
-                                name-symbol label x t allow-vector))) arg))
-   (t
-    (use-package-error
-     (concat label " wants a string, (string . symbol) or list of these")))))
+    (mapcar #'(lambda (x)
+                (let ((ret (use-package-normalize-pairs
+                            name-symbol label x t allow-vector)))
+                  (if (listp ret)
+                      (car ret)
+                    ret))) arg))
+   (t arg)))
 
 (defun use-package-normalize-binder (name-symbol keyword args)
   (use-package-as-one (symbol-name keyword) args
@@ -645,7 +647,10 @@ manually updated package."
 
 (defun use-package-handler/:bind
     (name-symbol keyword arg rest state &optional override)
-  (let ((commands (mapcar #'cdr arg)))
+  (let ((commands (remq nil (mapcar #'(lambda (arg)
+                                        (if (listp arg)
+                                            (cdr arg)
+                                          nil)) arg))))
     (use-package-concat
      (use-package-process-keywords name-symbol
        (use-package-sort-keywords


### PR DESCRIPTION
We transform it into (:map foo (...) (...)) in the normalizer, and
no longer warn about unknown sorts of arg.