### PR TITLE
Make :pin work reliably.

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -406,12 +406,13 @@ manually updated package."
     (package-initialize t)))
 
 (defun use-package-handler/:pin (name-symbol keyword archive-name rest state)
+  (when archive-name
+    (use-package-pin-package name-symbol archive-name))
   (let ((body (use-package-process-keywords name-symbol rest state)))
     ;; This happens at macro expansion time, not when the expanded code is
     ;; compiled or evaluated.
     (if (null archive-name)
         body
-      (use-package-pin-package name-symbol archive-name)
       (use-package-concat
        body
        `((push '(,name-symbol . ,archive-name)


### PR DESCRIPTION
Currently, :pin's handler works much the same way as all the others:
it expands the remaining keywords, then pins (if there is anything
there to pin) and expands the body appropriately.

Unfortunately, the purpose of :pin is to influence the behaviour of :ensure, and
because use-package has to pull in packages from ELPA at macro-expansion time
(so it can rely on package.el picking up necessary autoloads and the like from
the package definition). This means that if :ensure appears in the wrong place
in the handlers, by the time the :pin handler calls use-package-pin-package
(which ultimately adds the package to package-pinned-packages), the package has
already been loaded.

The solution is to call use-package-pin-package immediately, before doing the
expansion. This works in all situations: if :ensure's handler is called first,
it will call use-package-process-keywords before installing the package, so
:pin's handler will get called: if it is called second, :pin's handler will
still get a chance to get in first and pin the package before :ensure's handler
can run.
