### PR TITLE
fix quotation error

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -910,7 +910,7 @@ deferred until the prefix key sequence is pressed."
              config-body)
           `((if (not ,(use-package-load-name name t))
                 (ignore
-                 (message (format "Could not load %s" name)))
+                 (message (format "Could not load %s" ',name)))
               ,@config-body)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Emacs complained about `(void-variable name)` when package failed to load, now it properly loggs missing package to \*Messages\*

The error was introduced here: https://github.com/jwiegley/use-package/commit/a863840fe666e1ae71251d5515784890bf944376#diff-7d8cebd9ba9fff18a51d6ca83a396f34L895