### PR TITLE
use-package-as-string: use noerror parameter

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -168,7 +168,7 @@ convert it to a string and return that."
 (defun use-package-load-name (name &optional noerror)
   "Return a form which will load or require NAME depending on
 whether it's a string or symbol."
-  (if (stringp name) `(load ,name 'noerror) `(require ',name nil 'noerror)))
+  (if (stringp name) `(load ,name ',noerror) `(require ',name nil ',noerror)))
 
 (defun use-package-expand (name label form)
   "FORM is a list of forms, so `((foo))' if only `foo' is being called."


### PR DESCRIPTION
I made another quoting mistake in #225 (didn't test those error cases!) that might cause errors in loading packages to go unnoticed. I'm not sure if this is relevant for #246 or not (perhaps @edvorg might comment on that).

Anyway, since this conflicts with and is obsoleted by #247, **DO NOT merge** this if you're going to merge that one soon. I just figured I'd propose this since it seems #247 is sitting and in the mean time there is a bug in the code...