### PR TITLE
Pass in symbol of bind macro, for more extensible re-use of same handler

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -663,7 +663,7 @@ manually updated package."
 (defalias 'use-package-normalize/:bind* 'use-package-normalize-binder)
 
 (defun use-package-handler/:bind
-    (name keyword arg rest state &optional override)
+    (name keyword arg rest state &optional bind-macro)
   (let ((commands (remq nil (mapcar #'(lambda (arg)
                                         (if (listp arg)
                                             (cdr arg)
@@ -673,10 +673,10 @@ manually updated package."
        (use-package-sort-keywords
         (use-package-plist-maybe-put rest :defer t))
        (use-package-plist-append state :commands commands))
-     `((ignore (,(if override 'bind-keys* 'bind-keys) ,@arg))))))
+     `((ignore (,(if bind-macro bind-macro 'bind-keys) ,@arg))))))
 
 (defun use-package-handler/:bind* (name keyword arg rest state)
-  (use-package-handler/:bind name keyword arg rest state t))
+  (use-package-handler/:bind name keyword arg rest state 'bind-keys*))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;


### PR DESCRIPTION
Since I'm going to create a small extension library that adds support for the `:chords` keyword, it would be helpful to re-use the existing `use-package-handler/:bind` method. This allows the macro to be used in the handler to be passed in as an argument to allow for this in an external package.

related to #258