### PR TITLE
Miscellaneous small changes 

### DIFF
--- a/use-package-tests.el
+++ b/use-package-tests.el
@@ -46,5 +46,7 @@
 
 ;; Local Variables:
 ;; indent-tabs-mode: nil
+;; no-byte-compile: t
+;; no-update-autoloads: t
 ;; End:
 ;;; use-package-tests.el ends here

--- a/use-package.el
+++ b/use-package.el
@@ -904,7 +904,7 @@ deferred until the prefix key sequence is pressed."
           `((eval-after-load ,(if (symbolp name) `',name name)
               ',(macroexp-progn config-body))))
       (use-package--with-elapsed-timer
-          (format "Loading package %s" name)
+          (format "    Loading package %s" name)
         (if use-package-expand-minimally
             (use-package-concat
              (list (use-package-load-name name))

--- a/use-package.el
+++ b/use-package.el
@@ -1052,8 +1052,6 @@ this file.  Usage:
                               (plist-get args* :defines))
                     (with-demoted-errors
                         ,(format "Cannot load %s: %%S" name)
-                      ,(if use-package-verbose
-                           `(message "Compiling package %s" ',name-symbol))
                       ,(unless (plist-get args* :no-require)
                          (use-package-load-name name)))))))
 


### PR DESCRIPTION
These are some suggestions. Please pick and reject as you see fit, long live Magit. Anyways...

The first commit aligns the startup messages. I find that quite helpful because it makes the initial contents of `*Messages*` much more readable.

2th removes the "Compiling package foo". I found that message to be confusing, because `use-package` is not actually compiling any packages.

3th prevents `use-package-tests.el` from being compiled and autoloaded.