### PR TITLE
Move :ensure option execution from macro expansion phase to runtime phase

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -463,13 +463,11 @@ manually updated package."
 
 (defun use-package-handler/:ensure (name keyword ensure rest state)
   (let ((body (use-package-process-keywords name rest state)))
-    ;; This happens at macro expansion time, not when the expanded code is
-    ;; compiled or evaluated.
-    (let ((package-name (or (and (eq ensure t) (use-package-as-symbol name)) ensure)))
-      (when package-name
-        (require 'package)
-        (use-package-ensure-elpa package-name)))
-    body))
+    `((let ((package-name (or (and (eq ,ensure t) (use-package-as-symbol ',name)) ,ensure)))
+          (when package-name
+            (require 'package)
+            (use-package-ensure-elpa package-name)))
+        ,@body))) 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;


### PR DESCRIPTION
**Description:**
Currently `:ensure` option is executed during macro expansion time.

This results in issues like:
https://github.com/jwiegley/use-package/issues/260 and https://github.com/company-mode/company-mode/issues/387

**Issue:**
If you have `company-mode` installed, `use-package` installed and `use-package-always-ensure` set to `t`, then typing `(use-package 123|` will make `company-mode` macro-expand `use-package` macro which will trigger contacting package repositories and fetching `123` package.

**Solution:**
This pull request moves execution of `:ensure` option from macro expansion time to runtime.

**WARNING**
**Please, double-check and test everything!**
Macros are tricky things, I might forgot to add a backquote or something.

I have tested several cases locally and for me it worked as expected, solved the issue.
But I'm not sure if this works in all cases.

**Also**, note that using `company-mode` + `use-package` is still pretty slow because `use-package` is a huge macro and `company-mode` expands it on each auto-completion attempt.
