### PR TITLE
Handle case where keymap is a variable

### DIFF
--- a/bind-key.el
+++ b/bind-key.el
@@ -151,7 +151,8 @@ spelled-out keystrokes, e.g., \"C-c C-z\". See documentation of
                        (read-kbd-macro ,namevar)))
             (,kdescvar (cons (if (stringp ,namevar) ,namevar
                                (key-description ,namevar))
-                             (quote ,keymap)))
+                             (when ,keymap
+                               (quote ,keymap))))
             (,bindingvar (lookup-key (or ,keymap global-map)
                                      ,keyvar)))
        (add-to-list 'personal-keybindings


### PR DESCRIPTION
As seen in this issue: https://github.com/waymondo/use-package-chords/issues/3

```
(defun test-bind (key command &optional keymap)
  (bind-key key command keymap))

(test-bind "M-B" 'eww)
```

This makes `personal-keybindings` look like this:

```
((("M-B" . keymap) eww eww))
```

which throws an error when you do `M-x describe-personal-keybinds`. That `keymap` symbol is not what we want, we want this:

```
((("M-B") eww eww))
```

Which is what this pull request will fix. 

If there is a more idiomatic solution, feel free to use it.
