### PR TITLE
Move :pin out of macro expansion phase

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -419,23 +419,23 @@ manually updated package."
   (let ((archive-symbol (if (symbolp archive) archive (intern archive)))
         (archive-name   (if (stringp archive) archive (symbol-name archive))))
     (if (use-package--archive-exists-p archive-symbol)
-        (push (cons package archive-name) package-pinned-packages)
+        (add-to-list 'package-pinned-packages (cons package archive-name) t)
       (error "Archive '%s' requested for package '%s' is not available."
              archive-name package))
     (package-initialize t)))
 
 (defun use-package-handler/:pin (name keyword archive-name rest state)
-  (let ((body (use-package-process-keywords name rest state)))
-    ;; This happens at macro expansion time, not when the expanded code is
-    ;; compiled or evaluated.
-    (if (null archive-name)
-        body
-      (use-package-pin-package name archive-name)
-      (use-package-concat
-       body
-       `((push '(,(use-package-as-symbol name) . ,archive-name)
-               package-pinned-packages)
-         t)))))
+  (let ((body (use-package-process-keywords name rest state))
+        (pin-form (if archive-name
+                      `(use-package-pin-package ',name ,archive-name))))
+    ;; We want to avoid pinning packages when the `use-package'
+    ;; macro is being macro-expanded by elisp completion (see
+    ;; `lisp--local-variables'), but still do pin packages when
+    ;; byte-compiling to avoid requiring `package' at runtime.
+    (if (bound-and-true-p byte-compile-current-file)
+        (eval pin-form)              ; Eval when byte-compiling,
+      (push pin-form body))          ; or else wait until runtime.
+    body))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;

--- a/use-package.el
+++ b/use-package.el
@@ -419,7 +419,7 @@ manually updated package."
   (let ((archive-symbol (if (symbolp archive) archive (intern archive)))
         (archive-name   (if (stringp archive) archive (symbol-name archive))))
     (if (use-package--archive-exists-p archive-symbol)
-        (add-to-list 'package-pinned-packages (cons package archive-name) t)
+        (add-to-list 'package-pinned-packages (cons package archive-name))
       (error "Archive '%s' requested for package '%s' is not available."
              archive-name package))
     (package-initialize t)))
@@ -427,11 +427,10 @@ manually updated package."
 (defun use-package-handler/:pin (name keyword archive-name rest state)
   (let ((body (use-package-process-keywords name rest state))
         (pin-form (if archive-name
-                      `(use-package-pin-package ',name ,archive-name))))
-    ;; We want to avoid pinning packages when the `use-package'
-    ;; macro is being macro-expanded by elisp completion (see
-    ;; `lisp--local-variables'), but still do pin packages when
-    ;; byte-compiling to avoid requiring `package' at runtime.
+                      `(use-package-pin-package ',(use-package-as-symbol name)
+                                                ,archive-name))))
+    ;; Pinning should occur just before ensuring
+    ;; See `use-package-handler/:ensure'.
     (if (bound-and-true-p byte-compile-current-file)
         (eval pin-form)              ; Eval when byte-compiling,
       (push pin-form body))          ; or else wait until runtime.


### PR DESCRIPTION
Fix (but I'm not sure) for #299

Changes:

1) move `:pin` option out of macro-expansion phase 
(the same thing we did for the `:ensure` option)

2) fix order of `:pin` and `:ensure` options.
`use-package-sort-keywords` function works correctly and puts `:pin` before `:ensure` after sorting.
But, after macro-expansion `:pin`'s body appears after the `:ensure`s body.
So, it pins the package, but after the installation (which is obviously wrong).

3) replace 
`(push (cons package archive-name) package-pinned-packages)` 
with 
`(add-to-list 'package-pinned-packages (cons package archive-name) t)`
Because `push` doesn't check if entry is already a member of a list. 
Hence, if you have something like `(use-package test :pin melpa)` and eval that form N times, you will get N '(test . "melpa")` entries in your `package-pinned-packages` list.
`add-to-list` does the same thing as `push`, but also checks if entry is already there.

After this changes I have:
1) it inserts new entry into `package-pinned-packages` only once (no more bloating!)
2) if I `pin` to the wrong archive (which is not in `package-archives`), I get the error (`"Archive '%s' requested for package '%s' is not available."`)
3) if I `pin` to the correct archive, then it installs required package using that archive
4) if I `byte-compile`, then it correctly `pin`s and installs package

Example:
``` lisp
(pp-macroexpand-expression '(use-package markdown-mode :ensure t :pin melpa))
```
Gives:
``` lisp
(progn
  (use-package-pin-package 'markdown-mode "melpa")
  (progn
    (require 'package)
    (use-package-ensure-elpa 'markdown-mode))
  (let
      ((now ...))
    (message "%s..." "Loading package markdown-mode")
    (prog1
        (if ... ...)
      (let ... ...))))
```