### PR TITLE
Allow string values in cons for :bind keywords

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -644,8 +644,14 @@ manually updated package."
            (and allow-vector (vectorp (car x))))
        (symbolp (cdr x))))
 
+(defsubst use-package-is-string-pair (x)
+  "Return t if X has the type (STRING . STRING)."
+  (and (consp x)
+       (stringp (car x))
+       (stringp (cdr x))))
+
 (defun use-package-normalize-pairs
-    (name label arg &optional recursed allow-vector)
+    (name label arg &optional recursed allow-vector allow-string-cdrs)
   "Normalize a list of string/symbol pairs."
   (cond
    ((or (stringp arg) (and allow-vector (vectorp arg)))
@@ -655,16 +661,18 @@ manually updated package."
    ((and (not recursed) (listp arg) (listp (cdr arg)))
     (mapcar #'(lambda (x)
                 (let ((ret (use-package-normalize-pairs
-                            name label x t allow-vector)))
+                            name label x t allow-vector allow-string-cdrs)))
                   (if (listp ret)
                       (car ret)
                     ret))) arg))
+   ((and allow-string-cdrs (use-package-is-string-pair arg))
+    (list arg))
    (t arg)))
 
 (defun use-package-normalize-binder (name keyword args)
   (use-package-as-one (symbol-name keyword) args
     (lambda (label arg)
-      (use-package-normalize-pairs name label arg nil t))))
+      (use-package-normalize-pairs name label arg nil t t))))
 
 (defalias 'use-package-normalize/:bind 'use-package-normalize-binder)
 (defalias 'use-package-normalize/:bind* 'use-package-normalize-binder)
@@ -850,12 +858,13 @@ deferred until the prefix key sequence is pressed."
      (apply
       #'nconc
       (mapcar #'(lambda (command)
-                  (append
-                   `((unless (fboundp ',command)
-                       (autoload #',command ,name-string nil t)))
-                   (when (bound-and-true-p byte-compile-current-file)
-                     `((eval-when-compile
-                         (declare-function ,command ,name-string))))))
+                  (when (not (stringp command))
+                    (append
+                     `((unless (fboundp ',command)
+                         (autoload #',command ,name-string nil t)))
+                     (when (bound-and-true-p byte-compile-current-file)
+                       `((eval-when-compile
+                           (declare-function ,command ,name-string)))))))
               (delete-dups (plist-get state :commands))))
 
      body)))


### PR DESCRIPTION
It is possible with `bind-key` and `define-key` (and also `bind-chord`
and `key-chord-define`) to define a binding to a string's value, i.e:

``` elisp
(bind-key "C-;" "the ")
(bind-chord "^^" "λ")
```

This adds an option for `(use-package-normalize-pairs)` that allows
string values to be given with the `:bind` (and also `:chord`) keywords
to expand into these definitions.