### PR TITLE
Do not package-initialize on each :pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,12 +359,6 @@ Example:
 
 **NOTE**: the `:pin` argument has no effect on emacs versions < 24.4.
 
-**NOTE**: if you pin a lot of packages, it will be slightly slower to start
-Emacs compared to manually adding all packages to the
-`package-pinned-packages` variable.  However, should you do it this way, you
-need to keep track of when `(package-initialize)` is called, so letting
-`use-package` handle it for you is arguably worth the cost.
-
 ## Extending use-package with new or modified keywords
 
 Starting with version 2.0, `use-package` is based on an extensible framework

--- a/use-package.el
+++ b/use-package.el
@@ -422,8 +422,7 @@ manually updated package."
         (add-to-list 'package-pinned-packages (cons package archive-name))
       (error "Archive '%s' requested for package '%s' is not available."
              archive-name package))
-    (when (and (boundp 'package--initialized)
-	       (not package--initialized))
+    (unless (bound-and-true-p package--initialized)
       (package-initialize t))))
 
 (defun use-package-handler/:pin (name keyword archive-name rest state)

--- a/use-package.el
+++ b/use-package.el
@@ -422,7 +422,9 @@ manually updated package."
         (add-to-list 'package-pinned-packages (cons package archive-name))
       (error "Archive '%s' requested for package '%s' is not available."
              archive-name package))
-    (package-initialize t)))
+    (when (and (boundp 'package--initialized)
+	       (not package--initialized))
+      (package-initialize t))))
 
 (defun use-package-handler/:pin (name keyword archive-name rest state)
   (let ((body (use-package-process-keywords name rest state))


### PR DESCRIPTION
In #302 @adouzzy mentioned that using lots of `:pin` makes startup time very long.
Even main page says:
>NOTE: if you pin a lot of packages, it will be slightly slower to start Emacs compared to manually adding all packages to the package-pinned-packages variable. However, should you do it this way, you need to keep track of when (package-initialize) is called, so letting use-package handle it for you is arguably worth the cost.

I noticed that in `use-package-pin-package` function we always call `(package-initialize t)`.
(I don't know though if it's done for purpose or not. If yes, then ignore this pull request)

For some reasons, `package-initialize` does not check if `package` has already been initialized.
That function loads all descriptors and reads all archive contents.
Obviously, it's not a very fast function.

**Benchmarks:**
``` lisp
;; use-package-pin-package
(benchmark 100 '(use-package-pin-package "test1234" "gnu"))

;; add-to-list
(benchmark 100 '(add-to-list 'package-pinned-packages '(test1234 . "gnu")))

;; => Elapsed time: 13.770000s (3.888000s in 200 GCs)
;; => Elapsed time: 0.000000s
```

Whoah!

Inside `package.el` itself they do:
``` lisp
(unless package--initialized
  (package-initialize t))
```
Makes sense.

That's what I've done in this pull-request:
Check if `package--initialized` var is bound (just for sure) and then check it's value.
If it is `nil` then call `package-initialize t` once.
In all other cases assume that `package` has been initialized.

**Benchmarks (after this patch):**
``` lisp
;; use-package-pin-package
(benchmark 100 '(use-package-pin-package "test1234" "gnu"))

;; add-to-list
(benchmark 100 '(add-to-list 'package-pinned-packages '(test1234 . "gnu")))

;; => Elapsed time: 0.000000s
;; => Elapsed time: 0.000000s
```

@jwiegley @npostavs @thomasf 
Would you kindly review this pull-request and do some tests please?