### PR TITLE
Add new option `-always-pin'

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,8 @@ archives is also a valid use-case.
 By default `package.el` prefers `melpa` over `melpa-stable` due to the
 versioning `(> evil-20141208.623 evil-1.0.9)`, so even if you are tracking
 only a single package from `melpa`, you will need to tag all the non-`melpa`
-packages with the appropriate archive.
+packages with the appropriate archive. If this really annoys you, then you can
+set `use-package-always-pin` to set a default.
 
 If you want to manually keep a package updated and ignore upstream updates,
 you can pin it to `manual`, which as long as there is no repository by that

--- a/use-package.el
+++ b/use-package.el
@@ -71,6 +71,11 @@ then the expanded macros do their job silently."
   :type 'sexp
   :group 'use-package)
 
+(defcustom use-package-always-pin nil
+  "Treat every package as though it had specified `:pin SYM."
+  :type 'symbol
+  :group 'use-package)
+
 (defcustom use-package-minimum-reported-time 0.1
   "Minimal load time that will be reported.
 
@@ -1075,6 +1080,11 @@ this file.  Usage:
                    (if use-package-always-ensure
                        (use-package-plist-maybe-put
                         args0 :ensure use-package-always-ensure)
+                     args0)))
+           (args* (use-package-sort-keywords
+                   (if use-package-always-pin
+                       (use-package-plist-maybe-put
+                        args* :pin use-package-always-pin)
                      args0))))
 
       ;; When byte-compiling, pre-load the package so all its symbols are in


### PR DESCRIPTION
`use-package-always-pin' allows a default archive (or manual) to be
specified for all use-package statements, unless explicitly overridden.

I finally got irritated with wanted to stay on stable packages but finding one package has to be installed from MELPA.