### PR TITLE
When :ensure is used install package as a selected package.

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -462,7 +462,9 @@ manually updated package."
   (if (package-installed-p package)
       t
     (if (or (assoc package package-archive-contents) no-refresh)
-        (package-install package t)
+        (if (boundp 'package-selected-packages)
+            (package-install package t)
+            (package-install package))
       (progn
         (package-refresh-contents)
         (use-package-ensure-elpa package t)))))

--- a/use-package.el
+++ b/use-package.el
@@ -446,7 +446,7 @@ manually updated package."
 ;;
 ;; :ensure
 ;;
-
+(defvar package-archive-contents)
 (defun use-package-normalize/:ensure (name keyword args)
   (if (null args)
       t
@@ -462,7 +462,7 @@ manually updated package."
   (if (package-installed-p package)
       t
     (if (or (assoc package package-archive-contents) no-refresh)
-        (package-install package)
+        (package-install package t)
       (progn
         (package-refresh-contents)
         (use-package-ensure-elpa package t)))))


### PR DESCRIPTION
Also shutup bytecompiler about package-archive-contents.

* use-package.el (use-package-ensure-elpa): Add package to selected package
by using second arg of package install.