### PR TITLE
Quote variable in bind-keys*

### DIFF
--- a/bind-key.el
+++ b/bind-key.el
@@ -293,7 +293,7 @@ function symbol (unquoted)."
 ;;;###autoload
 (defmacro bind-keys* (&rest args)
   (macroexp-progn
-   (bind-keys-form (cons :map (cons override-global-map args)))))
+   (bind-keys-form `(:map override-global-map ,@args))))
 
 (defun get-binding-description (elem)
   (cond


### PR DESCRIPTION
bind-key.el (bind-keys*): `override-global-map` needs to be quoted so
the symbol is passed to `bind-keys-form` and not the value.

Fixes #323.

(Emacs CA already signed, if you should need it; though this is so small, I don't expect it to be a problem.)