### PR TITLE
Fix to ignore load error caused via :after

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -909,7 +909,7 @@ deferred until the prefix key sequence is pressed."
         (lambda (feat)
           `(eval-after-load
                (quote ,feat)
-             (quote (require (quote ,name)))))
+             (quote (require (quote ,name) nil t))))
         features)))
 
 (defun use-package-handler/:after (name keyword arg rest state)


### PR DESCRIPTION
To load some related packages as order using :after.

```lisp
(use-package multi-web-mode
  :after web-mode
  :config
  (message "both web-mode and multi-web-mode are available"))
```

However, when web-mode is installed and multi-web-mode is not installed, this error occurred.
> (file-error "Cannot open load file" "no such file or directory" "multi-web-mode")
