### PR TITLE
Fix imenu support for older versions

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -177,6 +177,9 @@ Must be set before loading use-package."
   :group 'use-package)
 
 (when use-package-enable-imenu-support
+  ;; Not defined in Emacs 24
+  (defvar lisp-mode-symbol-regexp
+    "\\(?:\\sw\\|\\s_\\|\\\\.\\)+")
   (add-to-list
    'lisp-imenu-generic-expression
    (list "Package"


### PR DESCRIPTION
lisp-mode-symbol-regexp was not defined in Emacs 24.5.