### PR TITLE
Improve imenu support

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -177,19 +177,17 @@ Must be set before loading use-package."
   :group 'use-package)
 
 (when use-package-enable-imenu-support
-  ;; Not defined in Emacs 24
-  (defvar lisp-mode-symbol-regexp
-    "\\(?:\\sw\\|\\s_\\|\\\\.\\)+")
-  (add-to-list
-   'lisp-imenu-generic-expression
-   (list "Package"
-         (purecopy (concat "^\\s-*("
-                           (eval-when-compile
-                             (regexp-opt
-                              '("use-package" "require")
-                              t))
-                           "\\s-+\\(" lisp-mode-symbol-regexp "\\)"))
-         2)))
+  (eval-after-load 'lisp-mode
+    `(let ((sym-regexp (or (bound-and-true-p lisp-mode-symbol-regexp)
+                           "\\(?:\\sw\\|\\s_\\|\\\\.\\)+")))
+       (add-to-list
+        'lisp-imenu-generic-expression
+        (list "Packages"
+              (concat "^\\s-*("
+                      ,(eval-when-compile
+                         (regexp-opt '("use-package" "require") t))
+                      "\\s-+\\(" sym-regexp "\\)")
+              2)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;


### PR DESCRIPTION
Instead of using defvar for lisp-mode-symbol-regexp, wait until
lisp-mode is loaded and check for its existence to avoid making
use-package the place where this variable is declared.

By the way, sorry for all of the changes. I wasn't thinking carefully when I did this the first time. 
