### PR TITLE
Move :init forms before :after and :demand

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -144,9 +144,9 @@ the user specified."
     :defines
     :functions
     :defer
+    :init
     :after
     :demand
-    :init
     :config
     :diminish
     :delight)


### PR DESCRIPTION
The docstring of use-package says that :init should run before the
package is loaded but using :after moves the require statement ahead of
:init when any package specified in :after is already loaded. In the
following example, in the first case bar-x might get set before or after
bar is loaded depending on if foo is already loaded at the time, while
the second case always sets bar-x first.

(use-package bar
  :after (foo)
  :init (setq bar-x 2)
  :config (bar-mode))

(use-package bar
  :init (setq bar-x 2)
  :config (bar-mode))

This commit fixes the issue and makes sure that bar-x is set before bar
is loaded by use-package. Fixes #352.