### PR TITLE
Update use-package.el

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -500,6 +500,8 @@ manually updated package."
 (defun use-package-ensure-elpa (package &optional no-refresh)
   (if (package-installed-p package)
       t
+    (if (and (not no-refresh) (assoc package package-pinned-packages))
+        (package-read-all-archive-contents))
     (if (or (assoc package package-archive-contents) no-refresh)
         (package-install package)
       (progn


### PR DESCRIPTION
`:pin` does not work with `:ensure`, because it doesn't add the package to package-pinned-packages until after reading the package archive contents.  This change causes the package archive contents to be reread if the package is pinned and `:ensure` is being used.