### PR TITLE
Make :ensure working for package that are built-in and also on (m)elpa.

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -486,6 +486,7 @@ manually updated package."
 ;; :ensure
 ;;
 (defvar package-archive-contents)
+(defvar package-alist)
 (declare-function package-desc-status "package")
 (declare-function package-read-all-archive-contents "package")
 
@@ -501,17 +502,13 @@ manually updated package."
                    "(an unquoted symbol name)")))))))
 
 (defun use-package-ensure-elpa (package &optional no-refresh)
-  (let* ((pkg       (assq package package-archive-contents))
-         (installed (and pkg (member (package-desc-status (cadr pkg))
-                                     '("installed" "dependency")))))
-    (if installed
+  (let* ((pkg (assq package package-alist)))
+    (if pkg
         t
       (when (and (not no-refresh) (assoc package package-pinned-packages))
-        (package-read-all-archive-contents)
-        (setq pkg (assq package package-archive-contents))
-        (setq installed (member (package-desc-status (cadr pkg))
-                                '("installed" "dependency"))))
-      (if (or (and pkg (not installed)) no-refresh)
+        (package-read-all-archive-contents))
+      (setq pkg (assq package package-archive-contents))
+      (if (or pkg no-refresh)
           (package-install (cadr pkg))
         (progn
           (package-refresh-contents)

--- a/use-package.el
+++ b/use-package.el
@@ -498,15 +498,18 @@ manually updated package."
                    "(an unquoted symbol name)")))))))
 
 (defun use-package-ensure-elpa (package &optional no-refresh)
-  (if (package-installed-p package)
-      t
-    (if (and (not no-refresh) (assoc package package-pinned-packages))
-        (package-read-all-archive-contents))
-    (if (or (assoc package package-archive-contents) no-refresh)
-        (package-install package)
-      (progn
-        (package-refresh-contents)
-        (use-package-ensure-elpa package t)))))
+  (let* ((pkg (assq package package-archive-contents))
+         (pkg-desc (cadr pkg)))
+    (if (member (package-desc-status pkg-desc)
+                '("installed" "dependency"))
+        t
+      (if (and (not no-refresh) (assoc package package-pinned-packages))
+          (package-read-all-archive-contents))
+      (if (or pkg no-refresh)
+          (package-install pkg-desc)
+        (progn
+          (package-refresh-contents)
+          (use-package-ensure-elpa package t))))))
 
 (defun use-package-handler/:ensure (name keyword ensure rest state)
   (let* ((body (use-package-process-keywords name rest state))

--- a/use-package.el
+++ b/use-package.el
@@ -486,6 +486,9 @@ manually updated package."
 ;; :ensure
 ;;
 (defvar package-archive-contents)
+(declare-function package-desc-status "package")
+(declare-function package-read-all-archive-contents "package")
+
 (defun use-package-normalize/:ensure (name keyword args)
   (if (null args)
       t
@@ -498,14 +501,13 @@ manually updated package."
                    "(an unquoted symbol name)")))))))
 
 (defun use-package-ensure-elpa (package &optional no-refresh)
-  (let* ((pkg (assq package package-archive-contents))
-         (pkg-desc (cadr pkg)))
+  (let ((pkg-desc (cadr (assq package package-archive-contents))))
     (if (member (package-desc-status pkg-desc)
                 '("installed" "dependency"))
         t
       (if (and (not no-refresh) (assoc package package-pinned-packages))
           (package-read-all-archive-contents))
-      (if (or pkg no-refresh)
+      (if (or (assq package package-archive-contents) no-refresh)
           (package-install pkg-desc)
         (progn
           (package-refresh-contents)


### PR DESCRIPTION
Typically org package.

* use-package.el (use-package-ensure-elpa): Do it.
package-installed-p is of no help, use another test.