### PR TITLE
Allow :ensure installing built-in package distributed also on (m)elpa.

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -486,6 +486,10 @@ manually updated package."
 ;; :ensure
 ;;
 (defvar package-archive-contents)
+(defvar package-alist)
+(declare-function package-desc-status "package")
+(declare-function package-read-all-archive-contents "package")
+
 (defun use-package-normalize/:ensure (name keyword args)
   (if (null args)
       t
@@ -498,13 +502,14 @@ manually updated package."
                    "(an unquoted symbol name)")))))))
 
 (defun use-package-ensure-elpa (package &optional no-refresh)
-  (if (package-installed-p package)
-      t
-    (if (and (not no-refresh) (assoc package package-pinned-packages))
+  (let ((pkg (assq package package-alist)))
+    (if pkg
+        t
+      (when (and (not no-refresh) (assoc package package-pinned-packages))
         (package-read-all-archive-contents))
-    (if (or (assoc package package-archive-contents) no-refresh)
-        (package-install package)
-      (progn
+      (setq pkg (assq package package-archive-contents))
+      (if (or pkg no-refresh)
+          (package-install (cadr pkg))
         (package-refresh-contents)
         (use-package-ensure-elpa package t)))))
 


### PR DESCRIPTION
This commit fix (use-package org :ensure t)
org being a built-in package but also a package distributed on elpa.
When a user use :ensure on such a package (already installed) we assume
it is the elpa version he wants to use.

* use-package.el (use-package-ensure-elpa):
Don't assume a package is installed because it is built-in.
Use the description of the package to ensure we don't try to install
the built-in one.

Add also some declarations to shutup byte compiler.