### PR TITLE
Ensure package-pinned-packages is bound before referencing it.

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -500,7 +500,8 @@ manually updated package."
 (defun use-package-ensure-elpa (package &optional no-refresh)
   (if (package-installed-p package)
       t
-    (if (and (not no-refresh) (assoc package package-pinned-packages))
+    (if (and (not no-refresh)
+             (assoc package (bound-and-true-p package-pinned-packages)))
         (package-read-all-archive-contents))
     (if (or (assoc package package-archive-contents) no-refresh)
         (package-install package)


### PR DESCRIPTION
Add a boundp guard to package-pinned-packages before referencing it in
use-package-ensure-elpa.

I'm just duplicating the boundp guard from use-package-pin-package. Let me know if you prefer another approach.

I've tested this on Ubuntu 14.04 and verified it no longer throws an error, but haven't tested much else. Specifically, I don't really use the :pin feature myself, and haven't actually tested to ensure that package pinning works as expected.

Fixes #375