### PR TITLE
Use tex instead of tex-site for AUCTeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ If you need to install a different package from the one named by
 `use-package`, you can specify it like this:
 
 ``` elisp
-(use-package tex-site
+(use-package tex
   :ensure auctex)
 ```
 


### PR DESCRIPTION
```
Using tex-site doesn't work with :defer as tex-site is automatically
loaded when the package is initialized.
```

Closes #379.