### PR TITLE
Increase :preface priority

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -126,6 +126,7 @@ the user specified."
 
 (defcustom use-package-keywords
   '(:disabled
+    :preface
     :pin
     :ensure
     :if
@@ -133,7 +134,6 @@ the user specified."
     :unless
     :requires
     :load-path
-    :preface
     :no-require
     :bind
     :bind*


### PR DESCRIPTION
The `README` describes the `:preface` keyword as occurring before everything but `:disabled`, yet the former is currently preceded by seven other keywords in addition to the latter.

Most importantly, `:preface` occurs after `:ensure` and the three conditional keywords, thus reducing its use for establishing definitions.