### PR TITLE
Delay decision whether to use eval-after-load until run-time

### DIFF
--- a/bind-key.el
+++ b/bind-key.el
@@ -241,9 +241,9 @@ function symbol (unquoted)."
       (cl-flet
           ((wrap (map bindings)
                  (if (and map pkg (not (eq map 'global-map)))
-                     (if (boundp map)
-                         bindings
-                       `((eval-after-load
+                     `((if (boundp ',map)
+                           (progn ,@bindings)
+                         (eval-after-load
                              ,(if (symbolp pkg) `',pkg pkg)
                            '(progn ,@bindings))))
                    bindings)))


### PR DESCRIPTION
```
Just because a keymap variable is bound at macro-expansion-time
doesn't mean that it must be bound at run-time too.

Change `bind-keys-form', which is used by `bind-keys' and other
macros, to return a form which delays the decision on whether to
wrap the binding forms with `eval-after-load' until run-time.
```

Fixes #378.