### PR TITLE
Fix use-package-defaults

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -1169,16 +1169,12 @@ this file.  Usage:
   (unless (member :disabled args)
     (let ((name-symbol (if (stringp name) (intern name) name))
           (args (use-package-normalize-plist name args)))
-      (let ((first-spec (car use-package-defaults))
-            (rest-specs (cdr use-package-defaults)))
-        (when (eval (nth 2 first-spec))
-          (setq args (use-package-plist-maybe-put
-                      args (nth 0 first-spec) (eval (nth 1 first-spec)))))
-        (dolist (spec rest-specs)
-          (when (eval (nth 2 spec))
-            (setq args (use-package-sort-keywords
+      (dolist (spec use-package-defaults)
+        (setq args (use-package-sort-keywords
+                    (if (eval (nth 2 spec))
                         (use-package-plist-maybe-put
-                         args (nth 0 spec) (eval (nth 1 spec))))))))
+                         args (nth 0 spec) (eval (nth 1 spec)))
+                      args))))
 
       ;; When byte-compiling, pre-load the package so all its symbols are in
       ;; scope.


### PR DESCRIPTION
This pull request is a continuation from https://github.com/jwiegley/use-package/pull/426#issuecomment-279479609 in response to #428 and #429, which it should fix.

The problem was indeed that I didn't quite replicate the exact logic of the original version. In the original version, for each keyword, `use-package-plist-maybe-put` was only called if the relevant predicate returned true, whereas `use-package-sort-keywords` was called unconditionally. In the new version, `use-package-sort-keywords` was also called only when the relevant predicate returned true.