### PR TITLE
[RFC] Extend capabilities of use-package-ensure-function

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -184,8 +184,12 @@ Must be set before loading use-package."
 
 (defcustom use-package-ensure-function 'use-package-ensure-elpa
   "Function that ensures a package is installed.
-This function is called with one argument, the package name as a
-symbol, by the `:ensure' keyword.
+This function is called with three arguments: the name of the
+package declared in the `use-package' form; the argument passed
+to `:ensure'; and the current `state' plist created by previous
+handlers. Note that this function is called whenever `:ensure' is
+provided, even if it is nil. It is up to the function to decide
+on the semantics of the various values for `:ensure'.
 
 The default value uses package.el to install the package."
   :type '(choice (const :tag "package.el" use-package-ensure-elpa)


### PR DESCRIPTION
### Should not be merged quite yet (but comments welcome)

    Modify the expected API of `use-package-ensure-function' so that it is
    passed three arguments: the name of the package declared in the
    `use-package' form; the argument passed to `:ensure'; and the current
    `state' plist created by previous handlers. (Previously, it was only
    given a single argument, which was the argument passed to `:ensure',
    or the name of the package declared in the `use-package' form, if the
    former was `t'.

    This allows for more flexibility in the capabilities of the
    `use-package-ensure-function' implementation. For example, its
    behavior can change depending on the values of other keywords, if
    those keywords modify the `state' plist appropriately.

I was thinking about how to get deferred installation working, and I
realized that my previous patch (#427) provided an insufficiently
general API for `use-package-ensure-function`. This fixes that, in
theory at least. (I haven't tested it extensively.)