### PR TITLE
[RFC] Support for deferred installation

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -221,16 +221,16 @@ with the appropriate value."
 
 (defcustom use-package-pre-ensure-function 'ignore
   "Function that is called upon installation deferral.
-It is called immediately with the same arguments as
-`use-package-ensure-function', but only if installation has been
-deferred. It is intended for package managers other than
-package.el which might want to activate the autoloads of a
-package immediately, if it's installed, but otherwise defer
-installation until later (if `:defer-install' is specified). The
-reason it is set to `ignore' by default is that package.el
-activates the autoloads for all known packages at initialization
-time, rather than one by one when the packages are actually
-requested."
+It is called immediately with the first three arguments that
+would be passed to `use-package-ensure-function' (the context
+keyword is omitted), but only if installation has been deferred.
+It is intended for package managers other than package.el which
+might want to activate the autoloads of a package immediately, if
+it's installed, but otherwise defer installation until later (if
+`:defer-install' is specified). The reason it is set to `ignore'
+by default is that package.el activates the autoloads for all
+known packages at initialization time, rather than one by one
+when the packages are actually requested."
   :type '(choice (const :tag "None" ignore)
                  (function :tag "Custom"))
   :group 'use-package)
@@ -695,7 +695,7 @@ If the package is installed, its entry is removed from
                 ;; Contexts in which the confirmation prompt is
                 ;; bypassed.
                 (member context '(:byte-compile :ensure :config))
-                (y-or-n-p (format "Install package %S?" name))))
+                (y-or-n-p (format "Install package %S?" package))))
           (progn
             (when (assoc package (bound-and-true-p package-pinned-packages))
               (package-read-all-archive-contents))


### PR DESCRIPTION
    First cut at :defer-install keyword

    This new keyword, if provided along with a non-nil value, causes the action
    of :ensure to be deferred until "necessary". Package installation can be
    triggered by the user calling the new interactive function
    `use-package-install-deferred-package', or by the feature declared by the
    `use-package' form being required. This latter behavior seems to be the
    simplest way to make sure that package installation actually takes place
    when it needs to, but it requires that an advice be added to `require',
    which may be considered overly intrusive. (Also, it's generally considered
    bad practice for functions in Emacs to put advice on other functions in
    Emacs.) Thus it may make sense to add an option or function to explicitly
    enable this behavior, if there does not turn out to be a better way to
    accomplish deferred installation.

    Documentation has not been updated to reflect :defer-install yet.

Considering how to address #409. I think that this is not the right
approach to take (esp. because autoloads are handled in the C code and
therefore do not respect the advice on `require`), but I thought I
would post my progress so far. I think I have an idea about how to
proceed.