### PR TITLE
Don't mutilate keyword arguments in :bind

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -964,12 +964,15 @@ If RECURSED is non-nil, recurse into sublists."
    ((use-package-is-pair arg key-pred val-pred)
     (list arg))
    ((and (not recursed) (listp arg) (listp (cdr arg)))
-    (mapcar #'(lambda (x)
-                (let ((ret (use-package-normalize-pairs
-                            key-pred val-pred name label x t)))
-                  (if (listp ret)
-                      (car ret)
-                    ret))) arg))
+    (let ((last-item nil))
+      (mapcar #'(lambda (x)
+                  (prog1
+                      (let ((ret (use-package-normalize-pairs
+                                  key-pred val-pred name label x t)))
+                        (if (and (listp ret) (not (keywordp last-item)))
+                            (car ret)
+                          ret))
+                    (setq last-item x))) arg)))
    (t arg)))
 
 (defun use-package-normalize-binder (name keyword args)

--- a/use-package.el
+++ b/use-package.el
@@ -969,6 +969,25 @@ If RECURSED is non-nil, recurse into sublists."
                   (prog1
                       (let ((ret (use-package-normalize-pairs
                                   key-pred val-pred name label x t)))
+                        ;; Currently, the handling of keyword
+                        ;; arguments by `use-package' and `bind-key'
+                        ;; is non-uniform and undocumented. As a
+                        ;; result, `use-package-normalize-pairs' (as
+                        ;; it is currently implemented) does not
+                        ;; correctly handle the keyword-argument
+                        ;; syntax of `bind-keys'. A permanent solution
+                        ;; to this problem will require a careful
+                        ;; consideration of the desired
+                        ;; keyword-argument interface for
+                        ;; `use-package' and `bind-key'. However, in
+                        ;; the meantime, we have a quick patch to fix
+                        ;; a serious bug in the handling of keyword
+                        ;; arguments. Namely, the code below would
+                        ;; normally unwrap lists that were passed as
+                        ;; keyword arguments (for example, the
+                        ;; `:filter' argument in `:bind') without
+                        ;; the (not (keywordp last-item)) clause. See
+                        ;; #447 for further discussion.
                         (if (and (listp ret) (not (keywordp last-item)))
                             (car ret)
                           ret))


### PR DESCRIPTION
The parsing logic in `use-package-normalize-pairs` is not designed to
deal with keyword arguments. However, `use-package-normalize-pairs` is
used to process the arguments to :bind, which can include keyword
arguments. These keyword arguments are supposed to be passed untouched
to the underlying `bind-keys` function, but there is a clause in
`use-package-normalize-pairs` that replaces lists with their first
element. Thus an invocation like:

```
(use-package company
  :bind (:map company-active-map
         :filter (company-explicit-action-p)
         ("RET" . company-complete-selection)))
```

Generates code like this:

```
(bind-keys
  :map company-active-map
  :filter company-explicit-action-p
  ("RET" . company-complete-selection))
```

Which generates an error since `company-explicit-action-p` is now
being referenced as a variable rather than a function.

The proper solution is to refactor the logic that goes into parsing
uses of :bind, but this commit adds a temporary patch to eliminate the
above problem, while trying to be as reverse-compatible as possible.
In particular it just inhibits the list-to-first-element
transformation when the previous element processed was a keyword.