### PR TITLE
Make use-package-normalize-value handle nil better

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -778,7 +778,8 @@ If the package is installed, its entry is removed from
 
 (defsubst use-package-normalize-value (label arg)
   "Normalize a value."
-  (cond ((symbolp arg)
+  (cond ((null arg) nil)
+        ((symbolp arg)
          `(symbol-value ',arg))
         ((functionp arg)
          `(funcall #',arg))


### PR DESCRIPTION
The previous version of `use-package-normalize-value`, when passed
nil, would return the list `(symbol-value (quote nil))`. This meant that
keywords which used `use-package-normalize-value` or the higher-level
normalizer `use-package-normalize-test` would get a non-nil
argument (i.e. the above list) even when the user specified nil to the
package.

This had the concrete impact of making it so that `:defer-install nil`
was treated as `:defer-install t`.

See https://github.com/jwiegley/use-package/pull/443#issuecomment-291745802.