### PR TITLE
Use recommended exec-path-from-shell predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ In another example, we can load things conditional on the operating system:
 
 ```
 (use-package exec-path-from-shell
-  :if (eq system-type 'darwin)
+  :if (memq window-system '(mac ns)
   :ensure t
   :config
   (exec-path-from-shell-initialize))

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ In another example, we can load things conditional on the operating system:
 
 ```
 (use-package exec-path-from-shell
-  :if (memq window-system '(mac ns)
+  :if (memq window-system '(mac ns))
   :ensure t
   :config
   (exec-path-from-shell-initialize))


### PR DESCRIPTION
Modification of @keithmantell's #451

This is what exec-path-from-shell recommends to run it conditionally. Unlike system-type, window-system is set to nil in terminals, preventing unnecessarily loading exec-path-from-shell (see https://github.com/purcell/exec-path-from-shell/pull/53#issuecomment-293078491).