### PR TITLE
Fix quoting error in failed autoload message

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -1199,7 +1199,7 @@ deferred until the prefix key sequence is pressed."
        (if (bound-and-true-p use-package--recursive-autoload)
            (use-package-error
             (format "Autoloading failed to define function %S"
-                    command))
+                    ',command))
          (when (use-package-install-deferred-package
                 ',package-name :autoload)
            (require ',package-name)


### PR DESCRIPTION
Just a minor error. I was doing something silly with my deferred installation, and triggered this (probably rare) case in the logic. Unfortunately, the error `void-variable command` prevented `use-package` from giving me a nice error message saying so.