### PR TITLE
Use Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: generic
+before_install:
+  - sudo add-apt-repository -y ppa:ubuntu-elisp
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq emacs-snapshot
+script: >
+  emacs -batch
+  -l bind-key.el
+  -l use-package.el
+  -l use-package-tests.el
+  -f ert-run-tests-batch-and-exit

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # `use-package`
 
+[![Build Status](https://travis-ci.org/jwiegley/use-package.svg?branch=master)](https://travis-ci.org/jwiegley/use-package)
+
 The `use-package` macro allows you to isolate package configuration in your
 `.emacs` file in a way that is both performance-oriented and, well, tidy.  I
 created it because I have over 80 packages that I use in Emacs, and things
@@ -235,7 +237,7 @@ buffer, so that you can debug the situation in an otherwise functional Emacs.
 ## Conditional loading
 
 You can use the `:if` keyword to predicate the loading and initialization of
-modules.  
+modules.
 
 For example, I only want `edit-server` running for my main,
 graphical Emacs, not for other Emacsen I may start at the command line:


### PR DESCRIPTION
While `use-package`'s test suite is currently limited in scope, I think it would be helpful to run it on a continuous integration service like Travis to encourage testing in new contributions.

If you would like to merge this, please enable Travis first by visiting [your profile](https://travis-ci.org/profile) and toggling `use-package`. Note that this uses a snapshot PPA to install Emacs, you'd need something fancier if you want to test against multiple Emacs versions or older versions. The test command just runs ERT in batch mode, but it would need to be updated if the source or test file lists are changed.