### PR TITLE
Protect against errors during package install

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -726,7 +726,7 @@ If the package is installed, its entry is removed from
                 ;; bypassed.
                 (member context '(:byte-compile :ensure :config))
                 (y-or-n-p (format "Install package %S?" package))))
-          (progn
+          (with-demoted-errors (format "Cannot load %s: %%S" name)
             (when (assoc package (bound-and-true-p package-pinned-packages))
               (package-read-all-archive-contents))
             (if (assoc package package-archive-contents)


### PR DESCRIPTION
If the network is missing and there is a new use-package with :ensure,
startup would fail part of the way through due package.el being unable
to reach the package repo.  This will catch that error and report it
while allowing startup to continue.

Discovered and fixed on an airplane.  :)