### PR TITLE
Use Travis' container environment for improved performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: generic
-before_install:
-  - sudo add-apt-repository -y ppa:ubuntu-elisp
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq emacs-snapshot
+dist: trusty
+addons:
+  apt:
+    packages:
+      - emacs
 script: >
   emacs -batch
   -l bind-key.el


### PR DESCRIPTION
Container builds on Travis generally start faster. I also replaced `ppa:ubuntu-elisp`'s `emacs-snapshot` with Ubuntu Trusty's official `emacs` package (version 24.3), since the container builds don't support that custom PPA.