### PR TITLE
Allow `:diminish` with no arguments.

### DIFF
--- a/use-package-tests.el
+++ b/use-package-tests.el
@@ -72,6 +72,18 @@
 
   )
 
+(ert-deftest use-package-normalize-diminish ()
+  (should (equal (use-package-normalize-diminish 'foopkg :diminish nil)
+                 '(foopkg-mode)))
+  (should (equal (use-package-normalize-diminish 'foopkg :diminish 'bar)
+                 '(bar)))
+  (should (equal (use-package-normalize-diminish 'foopkg :diminish "bar")
+                 '((foopkg-mode . "bar"))))
+  (should (equal (use-package-normalize-diminish 'foopkg :diminish 'foo-mode)
+                 '(foo-mode)))
+  (should (equal (use-package-normalize-diminish 'foopkg :diminish '(foo . "bar"))
+                 '((foo . "bar")))))
+
 ;; Local Variables:
 ;; indent-tabs-mode: nil
 ;; no-byte-compile: t

--- a/use-package.el
+++ b/use-package.el
@@ -1409,10 +1409,12 @@ deferred until the prefix key sequence is pressed."
      SYMBOL
      (SYMBOL . STRING)"
   (cond
+   ((not arg)
+    (list (use-package-as-mode name)))
    ((symbolp arg)
     (list arg))
    ((stringp arg)
-    (list (cons (intern (concat (use-package-as-string name) "-mode")) arg)))
+    (list (cons (use-package-as-mode name) arg)))
    ((and (consp arg) (stringp (cdr arg)))
     (list arg))
    ((and (not recursed) (listp arg) (listp (cdr arg)))


### PR DESCRIPTION
When given no arguments, have :diminish assume it should diminish a
mode named after the current package (the package’s name, with “-mode”
appended, if it’s not already) to an empty string.

When given only a string to diminish an implicit package name to, do
not append “-mode” to the package name if it already ends with
it.  (This is a backwards-incompatible change if someone was
diminishing a package named “foo-mode” implementing `foo-mode-mode`.)

Add test cases for `use-package-normalize-diminish`.

This addresses some of the redundancy mentioned in issue #288.