### PR TITLE
Fix bug in use-package-install-deferred-package

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -669,11 +669,12 @@ If the package is installed, its entry is removed from
               use-package--deferred-packages)
      (if packages
          (list
-          (completing-read
-           "Select package: "
-           packages
-           nil
-           'require-match)
+          (intern
+           (completing-read
+            "Select package: "
+            packages
+            nil
+            'require-match))
           :interactive)
        (user-error "No packages with deferred installation"))))
   (let ((spec (gethash name use-package--deferred-packages)))


### PR DESCRIPTION
Previously, deferred installation didn't work because I didn't convert the result of a `completing-read` back from a string to a symbol, which meant the hash-table lookup failed.