### PR TITLE
Don't use with-demoted-errors in use-package-ensure-elpa 

### DIFF
--- a/use-package.el
+++ b/use-package.el
@@ -741,14 +741,15 @@ If the package is installed, its entry is removed from
               (progn
                 (when (assoc package (bound-and-true-p package-pinned-packages))
                   (package-read-all-archive-contents))
-                (if (assoc package package-archive-contents)
-                    (progn (package-install package) t)
-                  (progn
-                    (package-refresh-contents)
-                    (when (assoc package (bound-and-true-p
-                                          package-pinned-packages))
-                      (package-read-all-archive-contents))
-                    (package-install package))))
+                (cond ((assoc package package-archive-contents)
+                       (package-install package)
+                       t)
+                      (t
+                       (package-refresh-contents)
+                       (when (assoc package
+                                    (bound-and-true-p package-pinned-packages))
+                         (package-read-all-archive-contents))
+                       (package-install package))))
             (error (message "Error: Cannot load %s: %S" name err)
                    nil))))))
 

--- a/use-package.el
+++ b/use-package.el
@@ -737,17 +737,20 @@ If the package is installed, its entry is removed from
                 ;; bypassed.
                 (member context '(:byte-compile :ensure :config))
                 (y-or-n-p (format "Install package %S?" package))))
-          (with-demoted-errors (format "Cannot load %s: %%S" name)
-            (when (assoc package (bound-and-true-p package-pinned-packages))
-              (package-read-all-archive-contents))
-            (if (assoc package package-archive-contents)
-                (progn (package-install package) t)
+          (condition-case-unless-debug err
               (progn
-                (package-refresh-contents)
-                (when (assoc package (bound-and-true-p
-                                      package-pinned-packages))
+                (when (assoc package (bound-and-true-p package-pinned-packages))
                   (package-read-all-archive-contents))
-                (package-install package))))))))
+                (if (assoc package package-archive-contents)
+                    (progn (package-install package) t)
+                  (progn
+                    (package-refresh-contents)
+                    (when (assoc package (bound-and-true-p
+                                          package-pinned-packages))
+                      (package-read-all-archive-contents))
+                    (package-install package))))
+            (error (message "Error: Cannot load %s: %S" name err)
+                   nil))))))
 
 (defun use-package-handler/:ensure (name keyword ensure rest state)
   (let* ((body (use-package-process-keywords name rest


### PR DESCRIPTION
It expects a literal string as argument at macro-expansion time, but we need to construct the message.

The second commit makes some cosmetic changes to that function, one of which makes a potential issue more visible.

The first clause ends with an explicit `t` implying that the return value is relevant, but the second does not. It is possible that its last form sometimes returns `nil` and sometimes non-nil and that relying on that value is the appropriate thing to do here. I did not check, but it is quite possible that the return value has to be set explicitly in the second clause too. Or maybe the return value does not matter at all and the explicit `t` in the first clause should be removed.