### PR TITLE
Add customization keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,21 @@ This does exactly the same thing as the following:
   :bind ("C-." . ace-jump-mode))
 ```
 
+## Package customization
+
+### Customizing variables.
+
+The `:custom` keyword allows customization of package custom variables.
+
+``` elisp
+(use-package comint
+  :custom
+  (comint-buffer-maximum-size 20000 "Increase comint buffer size.")
+  (comint-prompt-read-only t "Make the prompt read only."))
+```
+
+The documentation string is not mandatory.
+
 ## Notes about lazy loading
 
 In almost all cases you don't need to manually specify `:defer t`.  This is

--- a/README.md
+++ b/README.md
@@ -220,6 +220,16 @@ The `:custom` keyword allows customization of package custom variables.
 
 The documentation string is not mandatory.
 
+### Customizing faces
+
+The `:custom-face` keyword allows customization of package custom faces.
+
+``` elisp
+(use-package eruby-mode
+  :custom-face
+  (eruby-standard-face ((t (:slant italic)))))
+```
+
 ## Notes about lazy loading
 
 In almost all cases you don't need to manually specify `:defer t`.  This is

--- a/use-package.el
+++ b/use-package.el
@@ -159,6 +159,7 @@ the user specified."
     :functions
     :defer
     :custom
+    :custom-face
     :init
     :after
     :demand
@@ -1441,7 +1442,34 @@ deferred until the prefix key sequence is pressed."
              args)
      body)))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; :custom-face
+;;
 
+(defun use-package-normalize/:custom-face (name-symbol keyword arg)
+  "Normalize use-package custom-face keyword."
+  (let ((error-msg (format "%s wants a (<symbol> <face-spec>) or list of these" name-symbol)))
+    (unless (listp arg)
+      (use-package-error error-msg))
+    (dolist (def arg arg)
+      (unless (listp def)
+        (use-package-error error-msg))
+      (let ((face (nth 0 def))
+            (spec (nth 1 def)))
+        (when (or (not face)
+                  (not spec)
+                  (> (length arg) 2))
+          (use-package-error error-msg))))))
+
+(defun use-package-handler/:custom-face (name keyword args rest state)
+  "Generate use-package custom-face keyword code."
+  (let ((body (use-package-process-keywords name rest state)))
+    (use-package-concat
+     (mapcar (lambda (def)
+               `(custom-set-faces (quote ,def)))
+             args)
+     body)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
@@ -1590,6 +1618,7 @@ this file.  Usage:
 :diminish        Support for diminish.el (if installed).
 :delight         Support for delight.el (if installed).
 :custom          Call `customize-set-variable' with each variable definition.
+:custom-face     Call `customize-set-faces' with each face definition.
 :ensure          Loads the package using package.el if necessary.
 :pin             Pin the package to an archive."
   (declare (indent 1))


### PR DESCRIPTION
Hello,

This PR adds two new keyword: `:customize` and `:custom-faces`. These are shortcuts to cleanup calls to `customize-set-variable` and `custom-set-faces'`in the `:config` part. I do not use the Emacs internal save to custom.el setup because it's not easy to track in version control. I prefer to keep my package configuration in one place and these two keywords make this easier.

``` elisp
(use-package comint
  :customize
  (comint-buffer-maximum-size 20000 "Increase comint buffer size.")
  (comint-prompt-read-only t "Make the prompt read only."))

(use-package eruby-mode
  :custom-faces
  (eruby-standard-face ((t (:slant italic)))))
```

The comments are not mandatory for the `:customize` keyword.

I don't know if you would be willing to add these kind of keywords, so this PR is more about asking if theses features would be of interest for you to merge as I don't think this PR can be merged as is. I'm not sure about the normalizing function. They do not look like the other one because I did not really understood them, so I simply wrote ones that did the trick.

