### PR TITLE
Fix documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ or stop loading something you're not using at the present time:
   :commands R)
 ```
 
-When byte-compiling your `.emacs` file, disabled declarations are ommitted
+When byte-compiling your `.emacs` file, disabled declarations are omitted
 from the output entirely, to accelerate startup times.
 
 ## Byte-compiling your .emacs

--- a/use-package.el
+++ b/use-package.el
@@ -123,7 +123,7 @@ become available:
   `use-package--foo--pre-config-hook'
   `use-package--foo--post-config-hook'
 
-This way, you can add to these hooks before evalaution of a
+This way, you can add to these hooks before evaluation of a
 `use-package` declaration, and exercise some control over what
 happens.
 
@@ -290,7 +290,7 @@ found."
   "Attempt to find and jump to the `use-package' form that loaded
 PACKAGE. This will only find the form if that form actually
 required PACKAGE. If PACKAGE was previously required then this
-function will jump to the file that orginally required PACKAGE
+function will jump to the file that originally required PACKAGE
 instead."
   (interactive (list (completing-read "Package: " features)))
   (let* ((package (if (stringp package) (intern package) package))


### PR DESCRIPTION
One in the readme, two in the docstrings in use-package.el