### PR TITLE
Fix function accidentally made interactive

### DIFF
--- a/use-package-core.el
+++ b/use-package-core.el
@@ -819,7 +819,9 @@ representing symbols (that may need to be autloaded)."
 
 ;;;; :disabled
 
-(defalias 'use-package-normalize/:disabled 'ignore)
+;; Don't alias this to `ignore', as that will cause the resulting
+;; function to be interactive.
+(defun use-package-normalize/:disabled (name keyword arg rest state))
 
 (defun use-package-handler/:disabled (name keyword arg rest state)
   (use-package-process-keywords name rest state))


### PR DESCRIPTION
Previously, `M-x use-package` would give `use-package-normalize/:disabled` as a completion candidate which seemed a little odd to me.