### PR TITLE
Enable GitHub Pages deployment in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ dist: trusty
 env:
   global:
     - CURL="curl -fsSkL --retry 9 --retry-delay 9"
+  matrix:
+    - EMACS_VERSION=24.3
     - EMACS_VERSION=25
 install:
   - $CURL -O https://github.com/npostavs/emacs-travis/releases/download/bins/emacs-bin-${EMACS_VERSION}.tar.gz
@@ -18,6 +20,7 @@ deploy:
   local_dir: public
   on:
     branch: doc-site-cd
+    condition: $EMACS_VERSION = 25
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ deploy:
   skip_cleanup: true
   github_token: $GITHUB_TOKEN
   local_dir: doc/public
+  on:
+    branch: doc-site-cd
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
     packages:
       - emacs
 script: make test
-before_deploy: cd doc && make doc
+before_deploy: cd doc && make vtest doc
 deploy:
   provider: pages
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ addons:
     packages:
       - emacs
 script: make test
+before_deploy: cd doc && make doc HUGO_BASE_URL=https://jwiegley.github.io/use-package/
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN
+  local_dir: doc/public
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ deploy:
   provider: pages
   skip_cleanup: true
   github_token: $GITHUB_TOKEN
-  local_dir: doc/public
+  local_dir: public
   on:
     branch: doc-site-cd
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
     packages:
       - emacs
 script: make test
-before_deploy: cd doc && make doc HUGO_BASE_URL=https://jwiegley.github.io/use-package/
+before_deploy: cd doc && make doc
 deploy:
   provider: pages
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: generic
 dist: trusty
 env:
-  - CURL="curl -fsSkL --retry 9 --retry-delay 9"
-  - EMACS_VERSION=25
+  global:
+    - CURL="curl -fsSkL --retry 9 --retry-delay 9"
+    - EMACS_VERSION=25
 install:
   - $CURL -O https://github.com/npostavs/emacs-travis/releases/download/bins/emacs-bin-${EMACS_VERSION}.tar.gz
   - tar xf emacs-bin-${EMACS_VERSION}.tar.gz -C /

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
     packages:
       - emacs
 script: make test
-before_deploy: cd doc && make vtest doc
+before_deploy: cd doc && make doc
 deploy:
   provider: pages
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
     packages:
       - emacs
 script: make test
-before_deploy: cd doc && make vtest doc
+before_deploy: cd doc && make vcheck doc
 deploy:
   provider: pages
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: generic
 dist: trusty
-addons:
-  apt:
-    packages:
-      - emacs
+env:
+  - CURL="curl -fsSkL --retry 9 --retry-delay 9"
+  - EMACS_VERSION=25
+install:
+  - $CURL -O https://github.com/npostavs/emacs-travis/releases/download/bins/emacs-bin-${EMACS_VERSION}.tar.gz
+  - tar xf emacs-bin-${EMACS_VERSION}.tar.gz -C /
+  - export EMACS=/tmp/emacs/bin/emacs
+  - $EMACS --version
 script: make test
 before_deploy: cd doc && make doc
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
     packages:
       - emacs
 script: make test
-before_deploy: cd doc && make vcheck doc
+before_deploy: cd doc && make vtest doc
 deploy:
   provider: pages
   skip_cleanup: true

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -99,6 +99,7 @@ emacs-batch:
 	(setq-default make-backup-files nil)\
 	(load-file (expand-file-name \"setup-ox-hugo.el\" \"$(USE_PACKAGE_DOC_DIR)\"))\
 	)" $(ORG_FILE) \
+	-f toggle-debug-on-error
 	-f $(FUNC) \
 	--kill
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -99,7 +99,6 @@ emacs-batch:
 	(setq-default make-backup-files nil)\
 	(load-file (expand-file-name \"setup-ox-hugo.el\" \"$(USE_PACKAGE_DOC_DIR)\"))\
 	)" $(ORG_FILE) \
-	-f toggle-debug-on-error
 	-f $(FUNC) \
 	--kill
 


### PR DESCRIPTION
## [Preview](http://nickmccurdy.com/use-package/)

## Build Status
[![Build Status](https://travis-ci.org/nickmccurdy/use-package.svg?branch=doc-site-cd)](https://travis-ci.org/nickmccurdy/use-package)

Please ignore upstream Travis builds for this pull request and refer to the builds on my fork, https://travis-ci.org/nickmccurdy/use-package, instead. These builds are actually failing (do not merge yet) but unfortunately Travis doesn't run deployment scripts on pull requests coming from forks.

## Merging
1. Go to https://travis-ci.org/jwiegley/use-package/settings.
2. Add a new environment variable with the name `HUGO_BASE_URL`, value `https://jwiegley.github.io/use-package/` (assuming you don't want to use a custom domain), and logging `On` (this tells Travis it doesn't need to be encrypted which makes troubleshooting logs easier).
3. Merge the pull request (or squash merge if you want a cleaner history) on GitHub.
4. Change `branch: doc-site-cd` to `branch: doc-site`.
5. Whenever you decide to merge `doc-site` into master, you will also need to change `branch: doc-site` to `branch: master`.

## References
- [Gitter Chat](https://gitter.im/use-package/Lobby)
- [Travis: GitHub Pages Deployment](https://docs.travis-ci.com/user/deployment/pages/)
- [ox-hugo Travis Configuration](https://github.com/kaushalmodi/ox-hugo/blob/master/.travis.yml)