### PR TITLE
Minor fixes with use-package doc site

### DIFF
--- a/doc/setup-ox-hugo.el
+++ b/doc/setup-ox-hugo.el
@@ -1,4 +1,4 @@
-;; Time-stamp: <2017-12-07 11:58:00 kmodi>
+;; Time-stamp: <2017-12-07 16:58:38 kmodi>
 
 ;; Setup to test ox-hugo using emacs -Q and the latest stable version
 ;; of Org.
@@ -190,14 +190,3 @@ to be installed.")
   (with-eval-after-load 'ox
     (setq org-export-headline-levels 4) ;default is 3
     (add-to-list 'org-export-exclude-tags "ignore")))
-
-;; Wed Sep 20 13:37:06 EDT 2017 - kmodi
-;; Below does not get applies when running emacs --batch.. need to
-;; figure out a solution.
-(custom-set-variables
- '(safe-local-variable-values
-   (quote
-    ((org-hugo-footer . "
-
-[//]: # \"Exported with love from a post written in Org mode\"
-[//]: # \"- https://github.com/kaushalmodi/ox-hugo\"")))))

--- a/doc/themes/hugo-alabaster-theme/layouts/partials/footer.html
+++ b/doc/themes/hugo-alabaster-theme/layouts/partials/footer.html
@@ -1,6 +1,6 @@
 <div class="footer">
     {{ if .Site.Params.footer.show_powered_by -}}
-	Exported from <a href="https://raw.githubusercontent.com/jwiegley/use-package/doc-site/use-package.org"><code>use-package.org</code></a>
+	Exported from <a href="https://raw.githubusercontent.com/jwiegley/use-package/master/use-package.org"><code>use-package.org</code></a>
         using
         {{ with .Params.creator }}
             <a href="https://www.gnu.org/software/emacs/">{{ . | replaceRE "\\(Org.*" "" }}</a> &plus;

--- a/use-package.org
+++ b/use-package.org
@@ -26,7 +26,7 @@
 # FIXME: This is just a workaround.. hope to get a better solution in
 # the future.
 
-#+MACRO: link-jump @@texinfo:@ref{$1}@@@@hugo:[[$2][$1]]@@
+#+MACRO: link-jump @@texinfo:@ref{$1}@@@@hugo:[$1]($2)@@
 
 use-package is...
 


### PR DESCRIPTION
- Update the source link of the Org file in the site footer.
- Fix the Org macro link-jump for hugo exports
- Remove unrelated stuff from setup-ox-hugo.el (carry-forward from
  ox-hugo repo)