### PR TITLE
Use emacs 26 to build the doc site

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ deploy:
   local_dir: public
   on:
     branch: master
-    condition: $EMACS_VERSION = 25.3
+    condition: $EMACS_VERSION = 26
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
Emacs 26 ships with Org 9.1.x. So use that to build the doc site, as
then there won't be the need to install Org 9.x from Org Elpa.

This speeds up the doc site deployment by about a minute.