### PR TITLE
Move EMACS_VERSION=26 to the top so that the docs build first

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ env:
   global:
     - CURL="curl -fsSkL --retry 9 --retry-delay 9"
   matrix:
-  - EMACS_VERSION=24.3
-  - EMACS_VERSION=24.4
-  - EMACS_VERSION=24.5
-  - EMACS_VERSION=25.3
   - EMACS_VERSION=26
+  - EMACS_VERSION=25.3
+  - EMACS_VERSION=24.5
+  - EMACS_VERSION=24.4
+  - EMACS_VERSION=24.3
   - EMACS_VERSION=master
 install:
   - $CURL -O https://github.com/npostavs/emacs-travis/releases/download/bins/emacs-bin-${EMACS_VERSION}.tar.gz


### PR DESCRIPTION
The order of the emacs versions in the matrix is changed so that the CI job with emacs 26 runs first.

The doc site is generated using emacs 26, and so the doc site will be updated first. 
Other emacs versions are ordered so that the newer versions are tested first and then the older.

The master version of emacs is still kept at the last.