### PR TITLE
Render the use-package-report table using Org

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,8 +736,7 @@ initialization they've reached, and how much aggregate time they've spent
 (roughly), you can enable `use-package-compute-statistics` after loading
 `use-package` but before any `use-package` forms, and then run the command
 `M-x use-package-report` to see the results. The buffer displayed is an Org
-table for now, so just type `M-x orgtbl-mode` and then use `C-c C-c` to
-reformat the table. You can also use `C-c ^` in a column to sort it.
+table for now. You can use `C-c ^` in a column to sort it.
 
 ## Keyword Extensions
 

--- a/use-package-core.el
+++ b/use-package-core.el
@@ -972,6 +972,9 @@ meaning:
                      (float-time (gethash :preface-secs hash 0))
                      (float-time (gethash :use-package-secs hash 0))))))
      use-package-statistics)
+    (goto-char (point-min))
+    (orgtbl-mode)
+    (orgtbl-ctrl-c-ctrl-c nil)
     (display-buffer (current-buffer))))
 
 (defun use-package-statistics-gather (keyword name after)


### PR DESCRIPTION
I noticed that the "Gathering Statistics" instructions for rendering the Org
table could be automated for convenience. Now the table is reformatted
automatically, and you can still manually sort it. I'm not sorting it by default
to maintain the same order of use-package forms for easier troubleshooting.