### PR TITLE
Handle automatic macro expansion by elisp-completion-at-point

### DIFF
--- a/use-package-core.el
+++ b/use-package-core.el
@@ -559,6 +559,15 @@ extending any keys already present."
   (let* ((name-symbol (if (stringp name) (intern name) name))
          (name-string (symbol-name name-symbol)))
 
+    ;; The function `elisp--local-variables' inserts this unbound variable into
+    ;; macro forms to determine the locally bound variables for
+    ;; `elisp-completion-at-point'. It ends up throwing a lot of errors since it
+    ;; can occupy the position of a keyword (or look like a second argument to a
+    ;; keyword that takes one). Deleting it when it's at the top level should be
+    ;; harmless since there should be no locally bound variables to discover
+    ;; here anyway.
+    (setq args (delq 'elisp--witness--lisp args))
+
     ;; Reduce the set of keywords down to its most fundamental expression.
     (setq args (use-package-unalias-keywords name-symbol args))
 


### PR DESCRIPTION
The function `elisp--local-variables` inserts this unbound variable into macro
forms to determine the locally bound variables for
`elisp-completion-at-point`. It ends up throwing a lot of errors since it's not
a keyword. Deleting it doesn't seem to break anything with completion, so ignore
it for now.

Related to https://github.com/abo-abo/hydra/commit/b12d37ac00d4f677b7684ed1af7d04d996167dbb