### PR TITLE
Fix sanity check for correct :custom-face format

### DIFF
--- a/use-package-core.el
+++ b/use-package-core.el
@@ -1351,7 +1351,7 @@ no keyword implies `:all'."
             (spec (nth 1 def)))
         (when (or (not face)
                   (not spec)
-                  (> (length arg) 2))
+                  (> (length def) 2))
           (use-package-error error-msg))))))
 
 (defun use-package-handler/:custom-face (name keyword args rest state)


### PR DESCRIPTION
Instead of testing the lenght of each form passed to `:custom-face`,
the sanity check would test the number of forms passed to `:custom-face`,
causing it to fail when more than 2 face customisations are used.

Fixes #600.