### PR TITLE
Fix formatting of use-package-report table

### DIFF
--- a/use-package-core.el
+++ b/use-package-core.el
@@ -972,6 +972,9 @@ meaning:
                      (float-time (gethash :preface-secs hash 0))
                      (float-time (gethash :use-package-secs hash 0))))))
      use-package-statistics)
+    (require 'org-table)
+    (org-table-align)
+    (goto-char (point-min))
     (display-buffer (current-buffer))))
 
 (defun use-package-statistics-gather (keyword name after)


### PR DESCRIPTION
Use org-table-align to make it readable.