### PR TITLE
Prefer org-table-align to orgtbl-ctrl-c-ctrl-c

### DIFF
--- a/use-package-core.el
+++ b/use-package-core.el
@@ -983,7 +983,7 @@ meaning:
      use-package-statistics)
     (goto-char (point-min))
     (orgtbl-mode)
-    (orgtbl-ctrl-c-ctrl-c nil)
+    (org-table-align)
     (display-buffer (current-buffer))))
 
 (defun use-package-statistics-gather (keyword name after)


### PR DESCRIPTION
org-table-align is an autoloaded function so the byte compiler can
find it. orgtbl-ctrl-c-ctrl-c isn't so we get a warning about
undefined functions.