### PR TITLE
Change the local_dir value to match some upstream Travis change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ deploy:
   provider: pages
   skip_cleanup: true
   github_token: $GITHUB_TOKEN
-  local_dir: public
+  local_dir: doc/public
   on:
     branch: master
     condition: $EMACS_VERSION = 26


### PR DESCRIPTION
The site is published in <REPO ROOT>/doc/public. But for some reason,
the local_dir value of "public" worked earlier.

Some change in Travis in the last ~18 days now causes failure with
that exact same .travis.yml.

But changing the "local_dir" value from "public" to "doc/public" fixes
the issue.