### PR TITLE
Don't display section numbers in doc site

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,4 +1,4 @@
-# Time-stamp: <2017-12-07 14:46:01 kmodi>
+# Time-stamp: <2018-01-27 22:11:28 kmodi>
 
 # Makefile to generate use-package doc site
 
@@ -25,7 +25,7 @@ endif
 
 # HUGO_VERSION and HUGO_OS are used later in the vcheck rule only if
 # HUGO_exists has evaluated to "".
-HUGO_VERSION ?= 0.31.1
+HUGO_VERSION ?= 0.34
 # |--------------------|
 # | HUGO_OS            |
 # |--------------------|

--- a/doc/static/css/style.css
+++ b/doc/static/css/style.css
@@ -103,6 +103,11 @@ ul.task-list {
     padding-left: 1rem;
 }
 
+/* Don't display section numbers */
+.section-num {
+    display: none;
+}
+
 @media screen and (min-width: 1400px) {
     .toc {
         display: block;


### PR DESCRIPTION
ox-hugo now has a feature that the Org OPTIONS "num" gets respected. 

The use-package.org has this line:

    #+OPTIONS: H:4 num:3 toc:2 creator:t

So it makes sense to have section numbers in the Info manual, but probably not so much on the site.

An elegant way is to allow the section numbers be exported for the site too.. but simply hide them in CSS.
 
Also update Hugo version to 0.34