### PR TITLE
Support ":package" in use-package

### DIFF
--- a/use-package-bind-key.el
+++ b/use-package-bind-key.el
@@ -87,12 +87,14 @@ deferred until the prefix key sequence is pressed."
          ;;   :prefix STRING
          ;;   :filter SEXP
          ;;   :menu-name STRING
+         ;;   :package SYMBOL
          ((or (and (eq x :map) (symbolp (cadr arg)))
               (and (eq x :prefix) (stringp (cadr arg)))
               (and (eq x :prefix-map) (symbolp (cadr arg)))
               (and (eq x :prefix-docstring) (stringp (cadr arg)))
               (eq x :filter)
-              (and (eq x :menu-name) (stringp (cadr arg))))
+              (and (eq x :menu-name) (stringp (cadr arg)))
+              (and (eq x :package) (symbolp (cadr arg))))
           (setq args* (nconc args* (list x (cadr arg))))
           (setq arg (cddr arg)))
          ((listp x)


### PR DESCRIPTION
bind-key supports the keyword ":package" but use-package does not know that. Adding this should be helpful. In the future, maybe we could automatically fill in with the use-package package, but that could be a breaking change.