### PR TITLE
Encourage installation via https instead of http

### DIFF
--- a/use-package.org
+++ b/use-package.org
@@ -77,7 +77,7 @@ with it by reading the documentation in the Emacs manual, see
 #+BEGIN_SRC emacs-lisp
   (require 'package)
   (add-to-list 'package-archives
-               '("melpa" . "http://melpa.org/packages/") t)
+               '("melpa" . "https://melpa.org/packages/") t)
 #+END_SRC
 
 - To use Melpa-Stable:
@@ -85,7 +85,7 @@ with it by reading the documentation in the Emacs manual, see
 #+BEGIN_SRC emacs-lisp
   (require 'package)
   (add-to-list 'package-archives
-               '("melpa-stable" . "http://stable.melpa.org/packages/") t)
+               '("melpa-stable" . "https://stable.melpa.org/packages/") t)
 #+END_SRC
 
 Once you have added your preferred archive, you need to update the

--- a/use-package.texi
+++ b/use-package.texi
@@ -159,7 +159,7 @@ To use Melpa:
 @lisp
 (require 'package)
 (add-to-list 'package-archives
-	     '("melpa" . "http://melpa.org/packages/") t)
+	     '("melpa" . "https://melpa.org/packages/") t)
 @end lisp
 
 @itemize
@@ -170,7 +170,7 @@ To use Melpa-Stable:
 @lisp
 (require 'package)
 (add-to-list 'package-archives
-	     '("melpa-stable" . "http://stable.melpa.org/packages/") t)
+	     '("melpa-stable" . "https://stable.melpa.org/packages/") t)
 @end lisp
 
 Once you have added your preferred archive, you need to update the


### PR DESCRIPTION
use-package is one of the most popular emacs packages, so it's better to encourage safer installation practices than plain `http://`. I hope I didn't miss anything.

P.S. Cheers @jwiegley, thanks for your awesome work!