### PR TITLE
ensure-system-package cleanup

### DIFF
--- a/use-package-ensure-system-package.el
+++ b/use-package-ensure-system-package.el
@@ -23,9 +23,7 @@
 (require 'system-packages nil t)
 
 (eval-when-compile
-  (defvar system-packages-package-manager)
-  (defvar system-packages-supported-package-managers)
-  (defvar system-packages-use-sudo))
+  (declare-function system-packages-get-command "system-packages"))
 
 (defun use-package-ensure-system-package-install-command (pack)
   "Return the default install command for PACK."


### PR DESCRIPTION
The function introduced in #673 wasn't declared at compile time, and
it made byte compiler unhappy. Moreover, it was forgotten to remove
redundant compile time variables. Thanks @tarsius for pointing that
out.

This change
* Removes redundant variable declarations
* Adds `system-packages-get-command` function declaration.