### PR TITLE
Correct prefix keys after use-package-autoload-keymap

### DIFF
--- a/use-package-bind-key.el
+++ b/use-package-bind-key.el
@@ -61,7 +61,8 @@ deferred until the prefix key sequence is pressed."
               (bind-key* key keymap)
             (bind-key key keymap))
           (setq unread-command-events
-                (listify-key-sequence kv)))
+                (mapcar (lambda (ev) (cons t ev))
+                        (listify-key-sequence kv))))
       (use-package-error
        (format "package.el %s failed to define keymap %s"
                package keymap-symbol)))))


### PR DESCRIPTION
By adding events of the form (cons t event) to unread-command-events, Emacs
correctly updates this-command-keys for the subsequent use of the prefix.

Before this change, packages like my which-key were not getting the correct
prefix after use-package-autoload-keymap loaded the relevant package.

See https://github.com/justbur/emacs-which-key/issues/192