### PR TITLE
Place :chords at beginning of use-package-keywords

### DIFF
--- a/use-package-chords.el
+++ b/use-package-chords.el
@@ -37,7 +37,7 @@
    `(,(macroexpand
        `(bind-chords :package ,name ,@arg)))))
 
-(add-to-list 'use-package-keywords :chords t)
+(add-to-list 'use-package-keywords :chords)
 
 (provide 'use-package-chords)
 


### PR DESCRIPTION
When it is at the end, the keys don't get bound until after the package has been loaded, because it comes after :defer, which is bad.  Placing it at the beginning allows the key bindings to be mapped to auto-loaded functions before the package is loaded, so that a key chord press triggers the package load.