### PR TITLE
Issue warning when no package manager available.

### DIFF
--- a/use-package-ensure-system-package.el
+++ b/use-package-ensure-system-package.el
@@ -29,9 +29,10 @@
   "Return the default install command for PACK."
   (if system-packages-package-manager
       (system-packages-get-command 'install pack)
-    (display-warning 'use-package
+    (display-warning 'use-package-ensure-system-package
                      (format "Unable to ensure system package %s is installed" pack)
-                     :warning)))
+                     :warning)
+      nil))
 
 (defun use-package-ensure-system-package-consify (arg)
   "Turn `arg' into a cons of (`package-name' . `install-command')."

--- a/use-package-ensure-system-package.el
+++ b/use-package-ensure-system-package.el
@@ -27,7 +27,11 @@
 
 (defun use-package-ensure-system-package-install-command (pack)
   "Return the default install command for PACK."
-  (system-packages-get-command 'install pack))
+  (if system-packages-package-manager
+      (system-packages-get-command 'install pack)
+    (display-warning 'use-package
+                     (format "Unable to ensure system package %s is installed" pack)
+                     :warning)))
 
 (defun use-package-ensure-system-package-consify (arg)
   "Turn `arg' into a cons of (`package-name' . `install-command')."


### PR DESCRIPTION
When :ensure-system-package is encountered, but
system-packages-package-manager is nil, a warning will be issued that
the package cannot be verified rather than causing an error that
results in the enclosing use-package declaration to fail.

Fixes: https://github.com/jwiegley/use-package/issues/698