### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ The `:bind` keyword takes either a cons or a list of conses:
 
 The `:commands` keyword likewise takes either a symbol or a list of symbols.
 
-NOTE: Special keys like `tab` or `F1`-`Fn` can be written in square brackets,
-i.e. `[tab]` instead of `"tab"`. The syntax for the keybindings is similar to
+NOTE: Inside strings, special keys like `tab` or `F1`-`Fn` have to be written inside angle brackets, e.g. `"C-<up>"`.
+Standalone special keys (and some combinations) can be written in square brackets, e.g. `[tab]` instead of `"<tab>"`. The syntax for the keybindings is similar to
 the "kbd" syntax: see [https://www.gnu.org/software/emacs/manual/html_node/emacs/Init-Rebinding.html](https://www.gnu.org/software/emacs/manual/html_node/emacs/Init-Rebinding.html)
 for more information.
 


### PR DESCRIPTION
Added information on special keys.

I'm not sure how and when the square brackets functionality works with modifiers.

`[S-f10]` works in the example you provide:

```
(use-package helm :ensure t
  :bind (("M-x" . helm-M-x)
         ("M-<f5>" . helm-find-files)
         ([f10] . helm-buffers-list)
         ([S-f10] . helm-recentf)))
```

`[C-c C-left]` or `[C-left]` does not work when I try it like this:

```
(use-package hs-minor-mode
  :init (hs-minor-mode t)
  :bind (("C-c C-<up>"    . hs-hide-all)
         ("C-c C-<down>"  . hs-show-all)
         ;; ("C-c C-<left>" . hs-hide-block)
         ;; ([C-c C-left]  . hs-hide-block)
         ([C-left] . hs-hide-block)
         ("C-c C-<right>" . hs-show-block)))
```