### PR TITLE
[Fix #720] Install system packages using system-packages-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,6 +847,15 @@ a file path by providing a string like so:
   ("/Applications/Dash.app" . "brew cask install dash"))
 ```
 
+`:ensure-system-package` will use `system-packages-install` to install
+system packages, except where a custom command has been specified, in
+which case it will be executed verbatim by `async-shell-command`.
+
+Configuration variables `system-packages-package-manager` and
+`system-packages-use-sudo` will be honoured, but not for custom
+commands. Custom commands should include the call to sudo in the
+command if needed.
+
 ### `(use-package-chords)`
 
 The `:chords` keyword allows you to define


### PR DESCRIPTION
:ensure-system-package was installing packages by running
system-packages-get-command via async-shell-command. This meant that
system-packages-use-sudo wasn't being honoured.

This patch makes :ensure-system-package use system-packages-install
for all cases, except where a custom install command is supplied, in
which case async-shell-command is used.

This issue was introduced in 7303e89a8343fc7 [#673], as a fix for
[#661]. Prior to that commit, system-packages-use-sudo was being
honoured.

This patch also fixes a bug where a cons containing a lone symbol in a
list of conses causes nil to used as the package to install.