### PR TITLE
Add comparison to package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ created it because I have over 80 packages that I use in Emacs, and things
 were getting difficult to manage.  Yet with this utility my total load time is
 around 2 seconds, with no loss of functionality!
 
+Note that `use-package` is **not** a package manager! Although `use-package`
+does have the useful capability to interface with package managers (see
+[below](#package-installation)), its primary purpose is for the configuration
+and loading of packages.
+
 Notes for users upgrading to 2.x are located [at the bottom](#upgrading-to-2x).
 
 ## Installing use-package


### PR DESCRIPTION
In many tutorials, one of the first features of `use-package` mentioned after its use is introduced is its ability to call package managers. Here's three examples from three different tutorials:

> With it [`use-package`], I can automatically download and install other packages from the emacs package databases when it detects they're missing.

> ```
> (use-package smex
>  :ensure t
>  :bind (("M-x" . smex))
>  :config (smex-initialize))
> ```
> And now Emacs ensures the package is installed [...]

> ```
> (use-package general :ensure t)
> ```
> It should check for the general package and make sure it is accessible. If not, the :ensure t part of the previous chunks tells use-package to download it [...]

While this focus on downloading packages is understandable, as it is one of the most convenient pieces of functionality provided by `use-package`, it could be confusing to newcomers such as me who could confuse `use-package` with a package manager. I do know that in my case, this caused a horrible amount of mental confusion, which was only clarified once I saw #717.

To reduce this confusion I have added a small note to the top of `use-package` clarifying this in the hope that it could help other people who were confused like me.