### PR TITLE
Mention that :hook implies :defer in defer section

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ cells, or a string or regexp:
 ```
 
 If you aren't using `:commands`, `:bind`, `:bind*`, `:bind-keymap`,
-`:bind-keymap*`, `:mode`, or `:interpreter` (all of which imply `:defer`; see
+`:bind-keymap*`, `:mode`, `:interpreter`, or `:hook` (all of which imply `:defer`; see
 the docstring for `use-package` for a brief description of each), you can
 still defer loading with the `:defer` keyword:
 


### PR DESCRIPTION
In an attempt to clarify documentation.