### PR TITLE
Update the README for defer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1037,7 +1037,7 @@ this case, but that's a subtlety I'd rather avoid.
 ## :defer now accepts an optional integer argument
 
 `:defer [N]` causes the package to be loaded -- if it has not already been --
-after `N` seconds of idle time.
+after `N` seconds of idle time, where `N` is a float number.
 
 ``` elisp
 (use-package back-button


### PR DESCRIPTION
Some users still think that `:defer` only accepts an integer as an argument, while it can take a float (**SEE:** https://github.com/jwiegley/use-package/issues/709).

To further avoid this confusion, the `README.md` file has been updated.
