### PR TITLE
Add no-query option for pdf-tools-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ that `:magic-fallback` has a lower priority than `:mode`. For example:
   :load-path "site-lisp/pdf-tools/lisp"
   :magic ("%PDF" . pdf-view-mode)
   :config
-  (pdf-tools-install))
+  (pdf-tools-install :no-query))
 ```
 
 This registers an autoloaded command for `pdf-view-mode`, defers loading of


### PR DESCRIPTION
Without using the `no-query` option, when you install [pdf-tools](https://github.com/politza/pdf-tools), it will send you a dialog message (y/n) to proceed with the installation, which we want to avoid most of the time because it prevents the automatic installation of your packages.

**SEE**: [this issue](https://github.com/politza/pdf-tools/issues/312)