### PR TITLE
Fix declare style

### DIFF
--- a/use-package-core.el
+++ b/use-package-core.el
@@ -1562,7 +1562,7 @@ this file.  Usage:
 :custom-face     Call `customize-set-faces' with each face definition.
 :ensure          Loads the package using package.el if necessary.
 :pin             Pin the package to an archive."
-  (declare (indent 1))
+  (declare (indent defun))
   (unless (memq :disabled args)
     (macroexp-progn
      (use-package-concat
@@ -1580,8 +1580,6 @@ this file.  Usage:
                      name (error-message-string err)) :error)))))
       (when use-package-compute-statistics
         `((use-package-statistics-gather :use-package ',name t)))))))
-
-(put 'use-package 'lisp-indent-function 'defun)
 
 (provide 'use-package-core)
 


### PR DESCRIPTION
Hi!
`use-pacakge` specified lisp-indent-function to indent like `defun`.

Currently, use-package main macro specify indent as `(declare (indent 1))`,
then change indent mode like `defun`.

`(declare (indent defun))` is same effect. It is simple and useful when redefining it when debug.

---
- Current
  1.1. When eval `use-package` loaded.

  ```
  (get 'use-package 'lisp-indent-function)
  ;; => defun
  ```
  1.2. Then redefine `use-package`, and eval below. (indent broken while this value)

  ```
  (get 'use-package 'lisp-indent-function)
  ;; => 1
  ```
  1.3. Eval `(put 'use-package 'lisp-indent-function 'defun)` and eval below. (indent issue fixed)

  ```
  (get 'use-package 'lisp-indent-function)
  ;; => defun
  ```
- Changed
  2.1. When eval `use-package` loaded.

  ```
  (get 'use-package 'lisp-indent-function)
  ;; => defun
  ```
  2.2. Then redefine `use-package`.

  ```
  (get 'use-package 'lisp-indent-function)
  ;; => defun
  ```