### PR TITLE
use-package-ensure-system-package allows for booleans

### DIFF
--- a/use-package-ensure-system-package.el
+++ b/use-package-ensure-system-package.el
@@ -54,12 +54,14 @@
        (t
         (list (use-package-ensure-system-package-consify arg)))))))
 
-(defun use-package-ensure-system-package-exists? (file-or-exe)
+(defun use-package-ensure-system-package-exists? (file-or-sym)
   "If variable is a string, ensure the file path exists.
-If it is a symbol, ensure the binary exist."
-  (if (stringp file-or-exe)
-      (file-exists-p file-or-exe)
-    (executable-find (symbol-name file-or-exe))))
+If it is a symbol, check if a boolean or else ensure the binary exist."
+  (if (booleanp file-or-sym)
+      file-or-sym
+    (if (stringp file-or-sym)
+        (file-exists-p file-or-sym)
+      (executable-find (symbol-name file-or-sym)))))
 
 
 ;;;###autoload
@@ -69,7 +71,7 @@ If it is a symbol, ensure the binary exist."
     (use-package-concat
      (mapcar #'(lambda (cons)
                  `(unless (use-package-ensure-system-package-exists? ',(car cons))
-		    ,(cdr cons))) arg)
+                    ,(cdr cons))) arg)
      body)))
 
 (add-to-list 'use-package-keywords :ensure-system-package t)


### PR DESCRIPTION
**Summary:** Added in a small check to see if the inputted symbol is a boolean and return the boolean if it is, or else do as the function originally did to check file path or if the binary is installed.

**Logic:** Not all programs come as a file path or executable. An example would be `tuareg` installed using `opam`. Some ways to check if tuareg is installed would be like `opam list |grep tuareg` or `opam info tuareg`. We don't particularly how the user checks, as long as they entered a boolean (which allows us to be sure this code is safe). The user can define their own function to check if the package exists or not, and then `use-package-ensure-system-package` can use that boolean to install the package if necessary, or the user can continue using `use-package-ensure-system-package` as before.

**Notes:** 
- I used a nested if to allow for booleans. I don't forsee any other symbols making sense, but if need be, the function can be refactored to use [cond](https://www.gnu.org/software/emacs/manual/html_node/elisp/Conditionals.html).
- Should this be merged, we should probably also edit the readme later as well (and it'd be a new addition to the use-package.org I suppose).