### PR TITLE
Make custom-face evaluate elisp.

### DIFF
--- a/use-package-core.el
+++ b/use-package-core.el
@@ -1419,7 +1419,7 @@ no keyword implies `:all'."
 (defun use-package-handler/:custom-face (name _keyword args rest state)
   "Generate use-package custom-face keyword code."
   (use-package-concat
-   (mapcar #'(lambda (def) `(custom-set-faces (quote ,def))) args)
+   (mapcar #'(lambda (def) `(custom-set-faces (backquote ,def))) args)
    (use-package-process-keywords name rest state)))
 
 ;;;; :init

--- a/use-package-tests.el
+++ b/use-package-tests.el
@@ -1125,7 +1125,7 @@
   (match-expansion
    (use-package foo :custom-face (foo ((t (:background "#e4edfc")))))
    `(progn
-      (custom-set-faces '(foo ((t (:background "#e4edfc")))))
+      (custom-set-faces (backquote (foo ((t (:background "#e4edfc"))))))
       (require 'foo nil nil))))
 
 (ert-deftest use-package-test/:init-1 ()


### PR DESCRIPTION
Fix #696.

Use `backquote` instead of `quote`.