### PR TITLE
use `use-package-as-one` for normalizing `:ensure-system-package`

### DIFF
--- a/use-package-ensure-system-package.el
+++ b/use-package-ensure-system-package.el
@@ -46,7 +46,7 @@
 ;;;###autoload
 (defun use-package-normalize/:ensure-system-package (_name-symbol keyword args)
   "Turn `arg' into a list of cons-es of (`package-name' . `install-command')."
-  (use-package-only-one (symbol-name keyword) args
+  (use-package-as-one (symbol-name keyword) args
     (lambda (_label arg)
       (cond
        ((and (listp arg) (listp (cdr arg)))


### PR DESCRIPTION
re-submission of #744 off a feature branch

--

This makes the syntax options consistent with other `use-package`
keywords. Both of these are now valid:

```
(use-package format-all
  :ensure-system-package
  (prettier . "npm i -g prettier")
  (rufo . "gem install rufo"))

(use-package format-all
  :ensure-system-package
  ((prettier . "npm i -g prettier")
   (rufo . "gem install rufo")))
```