### PR TITLE
extract use-package-hook-handler-normalize-mode-symbols function

### DIFF
--- a/use-package-core.el
+++ b/use-package-core.el
@@ -1266,8 +1266,12 @@ meaning:
                             (concat (symbol-name sym)
                                     use-package-hook-name-suffix)))
                    (function ,fun)))
-             (if (use-package-non-nil-symbolp syms) (list syms) syms)))))
+             (use-package-hook-handler-flatten-mode-symbols syms)))))
     (use-package-normalize-commands args))))
+
+(defun use-package-hook-handler-flatten-mode-symbols (syms)
+  "Ensure that `SYMS' turns into a list of modes."
+  (if (use-package-non-nil-symbolp syms) (list syms) syms))
 
 ;;;; :commands
 

--- a/use-package-core.el
+++ b/use-package-core.el
@@ -1266,10 +1266,10 @@ meaning:
                             (concat (symbol-name sym)
                                     use-package-hook-name-suffix)))
                    (function ,fun)))
-             (use-package-hook-handler-flatten-mode-symbols syms)))))
+             (use-package-hook-handler-normalize-mode-symbols syms)))))
     (use-package-normalize-commands args))))
 
-(defun use-package-hook-handler-flatten-mode-symbols (syms)
+(defun use-package-hook-handler-normalize-mode-symbols (syms)
   "Ensure that `SYMS' turns into a list of modes."
   (if (use-package-non-nil-symbolp syms) (list syms) syms))
 


### PR DESCRIPTION
This function extraction 1) makes the code slightly more understandable and 2) allows for tinkerers like me to override the way mode symbols are passed into the `:hook` keyword hook generation.

For example, it lets me accomplish what I was looking for in #612 with the following:

```
(defun my-use-package-hook-handler-normalize-mode-symbols (syms)
  (if (use-package-non-nil-symbolp syms)
      (condition-case _err
          (symbol-value syms)
        (error
         (list syms)))
    syms))

(advice-add 'use-package-hook-handler-normalize-mode-symbols :override
            #'my-use-package-hook-handler-normalize-mode-symbols)

(defconst my-writing-modes '(org-mode markdown-mode fountain-mode git-commit-mode))

(use-package face-remap
  :hook
  (my-writing-modes . variable-pitch-mode))
```


