### PR TITLE
':local' keyword adding code to mode-hook

### DIFF
--- a/use-package-core.el
+++ b/use-package-core.el
@@ -100,7 +100,8 @@
     :load
     ;; This must occur almost last; the only forms which should appear after
     ;; are those that must happen directly after the config forms.
-    :config)
+    :config
+    :local)
   "The set of valid keywords, in the order they are processed in.
 The order of this list is *very important*, so it is only
 advisable to insert new keywords, never to delete or reorder
@@ -1516,6 +1517,31 @@ no keyword implies `:all'."
                    (list t)))))
      (when use-package-compute-statistics
        `((use-package-statistics-gather :config ',name t))))))
+
+;;;; :local
+
+(defun use-package-normalize/:local (name keyword args)
+  (let ((first-arg-name (symbol-name (caar args))))
+    (if (not (string-suffix-p "-hook" first-arg-name))
+        (let* ((sym-name (symbol-name name))
+               (addition (if (string-suffix-p "-mode" sym-name)
+                             "-hook"
+                           "-mode-hook"))
+               (hook (intern (concat sym-name addition))))
+          `((,hook . ,(use-package-normalize-forms name keyword args))))
+      (cl-loop for (hook . code) in args
+               collect `(,hook . ,(use-package-normalize-forms name keyword code))))))
+
+(defun use-package-handler/:local (name _keyword arg rest state)
+  (let* ((body (use-package-process-keywords name rest state)))
+    (use-package-concat
+     body
+     (cl-loop for (hook . code) in arg
+              for func-name = (intern (concat "use-package-func/" (symbol-name hook)))
+              collect (progn
+                        (push 'progn code)
+                        `(defun ,func-name () ,code))
+              collect `(add-hook ',hook ',func-name)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;


### PR DESCRIPTION
I noticed that I often add a special setup function or lambda to the mode hooks in use-package. Like in the example config of evil-org.
 ```
  (use-package evil-org
    :after (evil org)
    :hook (org-mode-hook . evil-org-mode)
    :config
    (add-hook 'evil-org-mode-hook
	      (lambda ()
	        (evil-org-set-key-theme)))
    (require 'evil-org-agenda)
    (evil-org-agenda-set-keys))
```
I wanted to get rid of this `add-hook` line and came up with the `:local` keyword
 ```
  (use-package evil-org
    :after (evil org)
    :hook (org-mode-hook . evil-org-mode)
    :config
    (require 'evil-org-agenda)
    (evil-org-agenda-set-keys)
    :local
    (evil-org-set-key-theme)
```
In this case it is guessed that the hook is `evil-org-mode-hook`.
This keyword also supports the definition of multiple hooks e.g.
```
  (use-package cc-mode
    :config
    (setq-default c-basic-offset 8)
    :local
    (c-mode-common-hook . ((setq-local tab-width 8)))
    (java-mode-hook . ((setq-local tab-width 4)
                       (setq-local c-basic-offset 4))))
```
Internally this creates `(defun use-package-func/java-mode-hook () ...)` and `(add-hook 'java-mode-hook 'use-package-func/java-mode-hook)` adds this function the correct hook (same for the c-mode-common-hook).

This is my first real elisp coding experience so feel free to point out any non idiomatic or stupid code :)
If you want to merge this PR I can add some documentation in the readme.

Cheers