### PR TITLE
optimization: constant folding for read-kbd-macro

### DIFF
--- a/bind-key.el
+++ b/bind-key.el
@@ -172,8 +172,9 @@ can safely be called at any time."
         (kdescvar (make-symbol "kdesc"))
         (bindingvar (make-symbol "binding")))
     `(let* ((,namevar ,key-name)
-            (,keyvar (if (vectorp ,namevar) ,namevar
-                       (read-kbd-macro ,namevar)))
+            (,keyvar ,(if (stringp key-name) (read-kbd-macro key-name)
+                        `(if (vectorp ,namevar) ,namevar
+                           (read-kbd-macro ,namevar))))
             (,kmapvar (or (if (and ,keymap (symbolp ,keymap))
                               (symbol-value ,keymap) ,keymap)
                           global-map))


### PR DESCRIPTION
to boost startup performance, it is better to avoid invoking
`read-kbd-macro` at run time which requires 'cl-lib.

it takes ~20ms to load cl-lib