### PR TITLE
Call hooks even if no config

### DIFF
--- a/use-package-core.el
+++ b/use-package-core.el
@@ -156,8 +156,7 @@ See also `use-package-defaults', which uses this value."
   :group 'use-package)
 
 (defcustom use-package-defaults
-  '(;; this '(t) has special meaning; see `use-package-handler/:config'
-    (:config '(t) t)
+  '((:config nil t)
     (:init nil t)
     (:catch t (lambda (name args)
                 (not use-package-expand-minimally)))
@@ -1468,7 +1467,7 @@ no keyword implies `:all'."
     (use-package-concat
      (when use-package-compute-statistics
        `((use-package-statistics-gather :config ',name nil)))
-     (if (or (null arg) (equal arg '(t)))
+     (if (and (null arg) (not use-package-inject-hooks))
          body
        (use-package-with-elapsed-timer
            (format "Configuring package %s" name-symbol)

--- a/use-package-core.el
+++ b/use-package-core.el
@@ -156,7 +156,8 @@ See also `use-package-defaults', which uses this value."
   :group 'use-package)
 
 (defcustom use-package-defaults
-  '((:config nil t)
+  '(;; this '(t) has special meaning; see `use-package-handler/:config'
+    (:config '(t) t)
     (:init nil t)
     (:catch t (lambda (name args)
                 (not use-package-expand-minimally)))
@@ -1467,7 +1468,7 @@ no keyword implies `:all'."
     (use-package-concat
      (when use-package-compute-statistics
        `((use-package-statistics-gather :config ',name nil)))
-     (if (and (null arg) (not use-package-inject-hooks))
+     (if (and (or (null arg) (equal arg '(t))) (not use-package-inject-hooks))
          body
        (use-package-with-elapsed-timer
            (format "Configuring package %s" name-symbol)

--- a/use-package-tests.el
+++ b/use-package-tests.el
@@ -1474,6 +1474,36 @@
              (config)
              t))))))
 
+(ert-deftest use-package-test/pre-post-hooks-with-:config ()
+  (let ((use-package-inject-hooks t))
+    (match-expansion
+     (use-package foo :config (config))
+     `(progn
+       (when
+           (run-hook-with-args-until-failure 'use-package--foo--pre-init-hook)
+         (run-hooks 'use-package--foo--post-init-hook))
+       (require 'foo nil nil)
+       (when
+           (run-hook-with-args-until-failure 'use-package--foo--pre-config-hook)
+         (config)
+         (run-hooks 'use-package--foo--post-config-hook))
+       t))))
+
+(ert-deftest use-package-test/pre-post-hooks-without-:config ()
+  ;; https://github.com/jwiegley/use-package/issues/785
+  (let ((use-package-inject-hooks t))
+    (match-expansion
+     (use-package foo)
+     `(progn
+        (when
+            (run-hook-with-args-until-failure 'use-package--foo--pre-init-hook)
+          (run-hooks 'use-package--foo--post-init-hook))
+        (require 'foo nil nil)
+        (when
+            (run-hook-with-args-until-failure 'use-package--foo--pre-config-hook)
+          (run-hooks 'use-package--foo--post-config-hook))
+        t))))
+
 (ert-deftest use-package-test-normalize/:diminish ()
   (should (equal (use-package-normalize-diminish 'foopkg :diminish nil)
                  '(foopkg-mode)))

--- a/use-package-tests.el
+++ b/use-package-tests.el
@@ -1501,6 +1501,7 @@
         (require 'foo nil nil)
         (when
             (run-hook-with-args-until-failure 'use-package--foo--pre-config-hook)
+          t
           (run-hooks 'use-package--foo--post-config-hook))
         t))))
 


### PR DESCRIPTION
Fixes #785 

I couldn't figure out what the special `(t)` value is for `:config`, so I left that in even though it seems to have identical effect to `nil`.