### PR TITLE
typo, should be a vector, not a bytecode object

### DIFF
--- a/use-package-core.el
+++ b/use-package-core.el
@@ -1030,10 +1030,10 @@ meaning:
   "Show current statistics gathered about use-package declarations."
   (setq tabulated-list-format
         ;; The sum of column width is 80 characters:
-        #[("Package" 25 t)
-          ("Status" 13 t)
-          ("Last Event" 23 t)
-          ("Time" 10 t)])
+        [("Package" 25 t)
+         ("Status" 13 t)
+         ("Last Event" 23 t)
+         ("Time" 10 t)])
   (tabulated-list-init-header))
 
 (defun use-package-statistics-gather (keyword name after)


### PR DESCRIPTION
Solves https://github.com/jwiegley/use-package/issues/842