### PR TITLE
Support keymap symbol in bind-key. Fix #845

### DIFF
--- a/bind-key.el
+++ b/bind-key.el
@@ -154,10 +154,12 @@ spelled-out keystrokes, e.g., \"C-c C-z\". See documentation of
 
 COMMAND must be an interactive function or lambda form.
 
-KEYMAP, if present, should be a keymap and not a quoted symbol.
+KEYMAP, if present, should be a keymap variable or symbol.
 For example:
 
   (bind-key \"M-h\" #'some-interactive-function my-mode-map)
+
+  (bind-key \"M-h\" #'some-interactive-function 'my-mode-map)
 
 If PREDICATE is non-nil, it is a form evaluated to determine when
 a key should be bound. It must return non-nil in such cases.
@@ -171,10 +173,11 @@ can safely be called at any time."
     `(let* ((,namevar ,key-name)
             (,keyvar (if (vectorp ,namevar) ,namevar
                        (read-kbd-macro ,namevar)))
+            (kmap (if (and ,keymap (symbolp ,keymap)) (symbol-value ,keymap) ,keymap))
             (,kdescvar (cons (if (stringp ,namevar) ,namevar
                                (key-description ,namevar))
-                             (quote ,keymap)))
-            (,bindingvar (lookup-key (or ,keymap global-map) ,keyvar)))
+                             (if (symbolp ,keymap) ,keymap (quote ,keymap))))
+            (,bindingvar (lookup-key (or kmap global-map) ,keyvar)))
        (let ((entry (assoc ,kdescvar personal-keybindings))
              (details (list ,command
                             (unless (numberp ,bindingvar)
@@ -183,11 +186,11 @@ can safely be called at any time."
              (setcdr entry details)
            (add-to-list 'personal-keybindings (cons ,kdescvar details))))
        ,(if predicate
-            `(define-key (or ,keymap global-map) ,keyvar
+            `(define-key (or kmap global-map) ,keyvar
                '(menu-item "" nil :filter (lambda (&optional _)
                                             (when ,predicate
                                               ,command))))
-          `(define-key (or ,keymap global-map) ,keyvar ,command)))))
+          `(define-key (or kmap global-map) ,keyvar ,command)))))
 
 ;;;###autoload
 (defmacro unbind-key (key-name &optional keymap)

--- a/use-package-tests.el
+++ b/use-package-tests.el
@@ -1936,6 +1936,12 @@
       (define-prefix-command 'my/map)
       (bind-key "<f1>" 'my/map nil nil))))
 
+(defvar test-map (make-keymap))
+
+(ert-deftest bind-key/845 ()
+  (bind-key "C-c f" 'ignore 'test-map)
+  (describe-personal-keybindings))
+
 ;; Local Variables:
 ;; indent-tabs-mode: nil
 ;; no-byte-compile: t

--- a/use-package-tests.el
+++ b/use-package-tests.el
@@ -1936,11 +1936,17 @@
       (define-prefix-command 'my/map)
       (bind-key "<f1>" 'my/map nil nil))))
 
-(defvar test-map (make-keymap))
 
 (ert-deftest bind-key/845 ()
-  (bind-key "C-c f" 'ignore 'test-map)
-  (describe-personal-keybindings))
+  (defvar test-map (make-keymap))
+  (bind-key "<f1>" 'ignore 'test-map)
+  (should (eq (lookup-key test-map (kbd "<f1>")) 'ignore))
+  (let ((binding (cl-find "<f1>" personal-keybindings :test 'string= :key 'caar)))
+    (message "test-map %s" test-map)
+    (message "binding %s" binding)
+    (should (eq (cdar binding) 'test-map))
+    (should (eq (nth 1 binding) 'ignore))
+    (should (eq (nth 2 binding) nil))))
 
 ;; Local Variables:
 ;; indent-tabs-mode: nil


### PR DESCRIPTION
Sometimes, there are packages such as [prettier](https://github.com/jscheid/prettier.el) that expose commands that one would like to bind to multiple modes in their mode hooks. In which case the mode map will likely be dynamically constructed from the mode symbol, and one would like to bind keys like the following:

```elisp
(dolist (mode '(css-mode js-mode ...))
  (let ((mode-hook (derived-mode-hook-name mode)))
    (add-hook mode-hook (lambda ()
       (bind-key "C-c f" 'prettier-prettify (derived-mode-map-name mode)))))
```
The problem is,  `bind-key` currently does not support `KEYMAP` supplied as a symbol, and if it is supplied as a `(symbol-value (derived-mode-map-name mode))`, there's no way to reverse lookup the name of the variable from the symbol value later on when constructing the buffer for `describe-personal-bindings`, hence #845 .

This PR proposes a fix to this problem by supporting KEYMAP as symbols, while preserving backward compatibility.