### PR TITLE
use-package-core.el: use the Emacs set-default function to avoid saving :custom vars twice

### DIFF
--- a/use-package-core.el
+++ b/use-package-core.el
@@ -1394,7 +1394,9 @@ no keyword implies `:all'."
               (comment (nth 2 def)))
           (unless (and comment (stringp comment))
             (setq comment (format "Customized with use-package %s" name)))
-          `(customize-set-variable (quote ,variable) ,value ,comment)))
+          `(funcall (or (get (quote ,variable) 'custom-set) #'set-default)
+                    (quote ,variable)
+                    ,value)))
     args)
    (use-package-process-keywords name rest state)))
 


### PR DESCRIPTION
This was discussed in #517 and I CC-ed @jwiegley on the emacs-devel discussion.

The change will ensure that `:custom` vars are not also saved to custom.el.

In my testing it worked correctly, I don't see custom.el entries for those variables anymore. Testing is welcome!