### PR TITLE
Remove use-package-font-lock-keywords

### DIFF
--- a/use-package-core.el
+++ b/use-package-core.el
@@ -309,13 +309,6 @@ Must be set before loading use-package."
                          lisp-imenu-generic-expression)))))
   :group 'use-package)
 
-(defconst use-package-font-lock-keywords
-  '(("(\\(use-package\\)\\_>[ \t']*\\(\\(?:\\sw\\|\\s_\\)+\\)?"
-     (1 font-lock-keyword-face)
-     (2 font-lock-constant-face nil t))))
-
-(font-lock-add-keywords 'emacs-lisp-mode use-package-font-lock-keywords)
-
 (defcustom use-package-compute-statistics nil
   "If non-nil, compute statistics concerned use-package declarations.
 View the statistical report using `use-package-report'. Note that


### PR DESCRIPTION
I don't know how long `use-package` plans on supporting older versions of Emacs, or if it's alright to remove some minimal features supporting those versions (<=25), but it would be really nice to remove the font-lock keywords it adds. These are already highlighted on Emacs 26+ and shouldn't be needed on these versions. Additionally, this should not break anything other than font-lock on older versions of Emacs.

Doom removes it (https://github.com/hlissner/doom-emacs/blob/develop/core/core-modules.el#L343-L345) and I do as well to make use-package highlighted the same as other macros (I have a number of small wrappers which set some defaults and pass through all other forms for convenience).