### PR TITLE
Preserve comment and set synthetic theme

### DIFF
--- a/use-package-core.el
+++ b/use-package-core.el
@@ -1394,7 +1394,8 @@ no keyword implies `:all'."
               (comment (nth 2 def)))
           (unless (and comment (stringp comment))
             (setq comment (format "Customized with use-package %s" name)))
-          `(customize-set-variable (quote ,variable) ,value ,comment)))
+          `(customize-set-variable (quote ,variable) ,value ,comment)
+          `(put ',variable 'theme-value '((use-package-synthetic-theme ignore-just-for-saving)))))
     args)
    (use-package-process-keywords name rest state)))
 

--- a/use-package-core.el
+++ b/use-package-core.el
@@ -1396,7 +1396,8 @@ no keyword implies `:all'."
             (setq comment (format "Customized with use-package %s" name)))
           `(funcall (or (get (quote ,variable) 'custom-set) #'set-default)
                     (quote ,variable)
-                    ,value)))
+                    ,value)
+          `(put (quote ,variable) 'saved-variable-comment ,comment)))
     args)
    (use-package-process-keywords name rest state)))
 

--- a/use-package-core.el
+++ b/use-package-core.el
@@ -1394,10 +1394,7 @@ no keyword implies `:all'."
               (comment (nth 2 def)))
           (unless (and comment (stringp comment))
             (setq comment (format "Customized with use-package %s" name)))
-          `(funcall (or (get (quote ,variable) 'custom-set) #'set-default)
-                    (quote ,variable)
-                    ,value)
-          `(put (quote ,variable) 'saved-variable-comment ,comment)))
+          `(customize-set-variable (quote ,variable) ,value ,comment)))
     args)
    (use-package-process-keywords name rest state)))
 

--- a/use-package-core.el
+++ b/use-package-core.el
@@ -43,6 +43,11 @@
 (require 'cl-lib)
 (require 'tabulated-list)
 
+;; Declare a synthetic theme for :custom variables.
+;; Necessary in order to avoid having those variables saved by custom.el.
+(deftheme use-package)
+(enable-theme 'use-package)
+
 (if (and (eq emacs-major-version 24) (eq emacs-minor-version 3))
     (defsubst hash-table-keys (hash-table)
       "Return a list of keys in HASH-TABLE."
@@ -1394,8 +1399,9 @@ no keyword implies `:all'."
               (comment (nth 2 def)))
           (unless (and comment (stringp comment))
             (setq comment (format "Customized with use-package %s" name)))
-          `(customize-set-variable (quote ,variable) ,value ,comment)
-          `(put ',variable 'theme-value '((use-package-synthetic-theme ignore-just-for-saving)))))
+          `(let ((custom--inhibit-theme-enable nil))
+             (custom-theme-set-variables 'use-package
+			                 '(,variable ,value nil () ,comment)))))
     args)
    (use-package-process-keywords name rest state)))
 

--- a/use-package-tests.el
+++ b/use-package-tests.el
@@ -1138,6 +1138,19 @@
         (get 'foo 'custom-set)
         (function set-default))
        'foo bar)
+      (set 'foo 'saved-variable-comment "Customized with use-package foo")
+      (require 'foo nil nil))))
+
+(ert-deftest use-package-test/:custom-with-comment1 ()
+  (match-expansion
+   (use-package foo :custom (foo bar "commented"))
+   `(progn
+      (funcall
+       (or
+        (get 'foo 'custom-set)
+        (function set-default))
+       'foo bar)
+      (set 'foo 'saved-variable-comment "commented")
       (require 'foo nil nil))))
 
 (ert-deftest use-package-test/:custom-face-1 ()

--- a/use-package-tests.el
+++ b/use-package-tests.el
@@ -1129,28 +1129,25 @@
     ;;                '((foo bar baz))))
     ))
 
+
 (ert-deftest use-package-test/:custom-1 ()
   (match-expansion
    (use-package foo :custom (foo bar))
    `(progn
-      (funcall
-       (or
-        (get 'foo 'custom-set)
-        (function set-default))
-       'foo bar)
-      (set 'foo 'saved-variable-comment "Customized with use-package foo")
+      (let
+          ((custom--inhibit-theme-enable nil))
+        (custom-theme-set-variables 'use-package
+                                    '(foo bar nil nil "Customized with use-package foo")))
       (require 'foo nil nil))))
 
 (ert-deftest use-package-test/:custom-with-comment1 ()
   (match-expansion
    (use-package foo :custom (foo bar "commented"))
    `(progn
-      (funcall
-       (or
-        (get 'foo 'custom-set)
-        (function set-default))
-       'foo bar)
-      (set 'foo 'saved-variable-comment "commented")
+      (let
+          ((custom--inhibit-theme-enable nil))
+        (custom-theme-set-variables 'use-package
+                                    '(foo bar nil nil "commented")))
       (require 'foo nil nil))))
 
 (ert-deftest use-package-test/:custom-face-1 ()


### PR DESCRIPTION
This attempts to resolve #861 and #856 after #850 was merged as follows:

* revert to old `customize-set-variable` call instead of `set-default`
* add a synthetic theme property that's enough to prevent the customized variable from getting saved, which was the original goal of #850 
* the synthetic theme property is not enough to add the customized variable to the `custom-set-faces` portion of the customize save file
* this follows advice from @link0ff and @evelineraine and others in the above referenced PRs and bug reports for which I'm very grateful
* this should restore the minor-mode custom set behavior
* tests may need fixing