### PR TITLE
Use a single let binding when expanding consecutive :custom forms

### DIFF
--- a/use-package-core.el
+++ b/use-package-core.el
@@ -1397,17 +1397,18 @@ no keyword implies `:all'."
 (defun use-package-handler/:custom (name _keyword args rest state)
   "Generate use-package custom keyword code."
   (use-package-concat
-   (mapcar
-    #'(lambda (def)
-        (let ((variable (nth 0 def))
-              (value (nth 1 def))
-              (comment (nth 2 def)))
-          (unless (and comment (stringp comment))
-            (setq comment (format "Customized with use-package %s" name)))
-          `(let ((custom--inhibit-theme-enable nil))
-             (custom-theme-set-variables 'use-package
-			                 '(,variable ,value nil () ,comment)))))
-    args)
+   `((let ((custom--inhibit-theme-enable nil))
+       (custom-theme-set-variables
+        'use-package
+        ,@(mapcar
+           #'(lambda (def)
+               (let ((variable (nth 0 def))
+                     (value (nth 1 def))
+                     (comment (nth 2 def)))
+                 (unless (and comment (stringp comment))
+                   (setq comment (format "Customized with use-package %s" name)))
+                 `'(,variable ,value nil () ,comment)))
+           args))))
    (use-package-process-keywords name rest state)))
 
 ;;;; :custom-face


### PR DESCRIPTION
This is a small optimization for #881 / #899 (FYI @tzz). With the current `master` the following
```elisp
(use-package recentf
  :demand t

  :custom
  (recentf-max-saved-items 1000)
  (recentf-max-menu-items 500)
  (recentf-auto-cleanup (* 5 60))
  (recentf-mode t))
```
expands to
```elisp
(progn
  (let
      ((custom--inhibit-theme-enable nil))
    (custom-theme-set-variables 'use-package
                                '(recentf-max-saved-items 1000 nil nil "Customized with use-package recentf")))
  (let
      ((custom--inhibit-theme-enable nil))
    (custom-theme-set-variables 'use-package
                                '(recentf-max-menu-items 500 nil nil "Customized with use-package recentf")))
  (let
      ((custom--inhibit-theme-enable nil))
    (custom-theme-set-variables 'use-package
                                '(recentf-auto-cleanup
                                  (* 5 60)
                                  nil nil "Customized with use-package recentf")))
  (let
      ((custom--inhibit-theme-enable nil))
    (custom-theme-set-variables 'use-package
                                '(recentf-mode t nil nil "Customized with use-package recentf")))
  (require 'recentf nil nil))
```
With this change it will expand to:
```elisp
(progn
  (let
      ((custom--inhibit-theme-enable nil))
    (custom-theme-set-variables 'use-package
                                '(recentf-max-saved-items 1000 nil nil "Customized with use-package recentf")
                                '(recentf-max-menu-items 500 nil nil "Customized with use-package recentf")
                                '(recentf-auto-cleanup
                                  (* 5 60)
                                  nil nil "Customized with use-package recentf")
                                '(recentf-mode t nil nil "Customized with use-package recentf")))
  (require 'recentf nil nil))
```