### PR TITLE
Add use-package-use-theme and avoid missing theme errors

### DIFF
--- a/use-package-tests.el
+++ b/use-package-tests.el
@@ -1136,6 +1136,10 @@
    `(progn
       (let
           ((custom--inhibit-theme-enable nil))
+        (unless (memq 'use-package custom-known-themes)
+          (deftheme use-package)
+          (enable-theme 'use-package)
+          (setq custom-enabled-themes (remq 'use-package custom-enabled-themes)))
         (custom-theme-set-variables 'use-package
                                     '(foo bar nil nil "Customized with use-package foo")))
       (require 'foo nil nil))))
@@ -1146,6 +1150,10 @@
    `(progn
       (let
           ((custom--inhibit-theme-enable nil))
+        (unless (memq 'use-package custom-known-themes)
+          (deftheme use-package)
+          (enable-theme 'use-package)
+          (setq custom-enabled-themes (remq 'use-package custom-enabled-themes)))
         (custom-theme-set-variables 'use-package
                                     '(foo bar nil nil "commented")))
       (require 'foo nil nil))))


### PR DESCRIPTION
Addresses #902 

* new defcustom `use-package-use-theme` to disable themes
* define the synthetic theme every time it might be needed to avoid issues reported in #902 