### PR TITLE
require ox-hugo doesn't error if not found

### DIFF
--- a/doc/setup-ox-hugo.el
+++ b/doc/setup-ox-hugo.el
@@ -178,7 +178,7 @@ Emacs installation.  If Emacs is installed using
   ;; (message (list-load-path-shadows :stringp))
   )
 
-(require 'ox-hugo)
+(require 'ox-hugo nil t)
 (defun org-hugo-export-all-wim-to-md ()
   (org-hugo-export-wim-to-md :all-subtrees nil nil :noerror))
 


### PR DESCRIPTION
In case ox-hugo is not present, requiring the file won't throw an error.

The motivation for this change is that emacs-ng (https://github.com/emacs-ng/emacs-ng/issues/98) wants to bundle some packages by default that are not (yet?) in default GNUEmacs.

Using submodules is what feels easiest, but that `require` makes the build fail. When use-package will be part of emacs this won't be needed, but if we get this merged, we can get a headstart there.

I've my FSF papers signed and on file :+1: (for 1 line it probably doesn't matter, but anyway)