### PR TITLE
Add GitHub Actions config yaml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+## test.yml
+
+name: Main workflow
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        emacs_version:
+          - '26.1'
+          - '26.2'
+          - '26.3'
+          - '27.1'
+          - 'snapshot'
+        include:
+          - emacs_version: 'snapshot'
+            allow_failure: true
+    steps:
+    - uses: actions/checkout@v2
+    - uses: purcell/setup-emacs@master
+      with:
+        version: ${{ matrix.emacs_version }}
+
+    - name: Run tests
+      if: matrix.allow_failure != true
+      run: 'make && make test'
+
+    - name: Run tests (allow failure)
+      if: matrix.allow_failure == true
+      run: 'make && make test || true'


### PR DESCRIPTION
Add GitHub Actions config yaml.

This PR is just introduce GitHub Actions config yaml for test CI.
There're no doc jobs, so there're more work to move GitHub
Actions completely.