### PR TITLE
Add :autoload keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ and within the `isearch-mode-map` (see next section).  When the package is
 actually loaded (by using one of these commands), `moccur-edit` is also
 loaded, to allow editing of the `moccur` buffer.
 
+If you autoload no-interactive function, please use `:autoload`.
+
+```elisp
+(use-package org-crypt
+  :autoload org-crypt-use-before-save-magic)
+```
+
 ## Key-binding
 
 Another common thing to do when loading a module is to bind a key to primary

--- a/use-package-core.el
+++ b/use-package-core.el
@@ -94,6 +94,7 @@
     ;; Any other keyword that also declares commands to be autoloaded (such as
     ;; :bind) must appear before this keyword.
     :commands
+    :autoload
     :init
     :defer
     :demand
@@ -118,7 +119,8 @@ declaration is incorrect."
 (defcustom use-package-deferring-keywords
   '(:bind-keymap
     :bind-keymap*
-    :commands)
+    :commands
+    :autoload)
   "Unless `:demand' is used, keywords in this list imply deferred loading.
 The reason keywords like `:hook' are not in this list is that
 they only imply deferred loading if they reference actual
@@ -1309,6 +1311,28 @@ meaning:
       (delete-dups arg)))
    (use-package-process-keywords name rest state)))
 
+;;;; :autoload
+
+(defalias 'use-package-normalize/:autoload 'use-package-normalize/:commands)
+
+(defun use-package-handler/:autoload (name _keyword arg rest state)
+  (use-package-concat
+   ;; Since we deferring load, establish any necessary autoloads, and also
+   ;; keep the byte-compiler happy.
+   (let ((name-string (use-package-as-string name)))
+     (cl-mapcan
+      #'(lambda (command)
+          (when (symbolp command)
+            (append
+             (unless (plist-get state :demand)
+               `((unless (fboundp ',command)
+                   (autoload #',command ,name-string))))
+             (when (bound-and-true-p byte-compile-current-file)
+               `((eval-when-compile
+                   (declare-function ,command ,name-string)))))))
+      (delete-dups arg)))
+   (use-package-process-keywords name rest state)))
+
 ;;;; :defer
 
 (defalias 'use-package-normalize/:defer 'use-package-normalize-predicate)
@@ -1570,6 +1594,7 @@ this file.  Usage:
                  package.  This is useful if the package is being lazily
                  loaded, and you wish to conditionally call functions in your
                  `:init' block that are defined in the package.
+:autoload        Similar to :commands, but it for no-interactive one.
 :hook            Specify hook(s) to attach this package to.
 
 :bind            Bind keys, and define autoloads for the bound commands.

--- a/use-package-tests.el
+++ b/use-package-tests.el
@@ -889,6 +889,12 @@
           (gnus-harvest-install))
         t))))
 
+(ert-deftest use-package-test/:autoload-1 ()
+  (match-expansion
+   (use-package foo :autoload bar)
+   `(unless (fboundp 'bar)
+      (autoload #'bar "foo"))))
+
 (ert-deftest use-package-test/:defines-1 ()
   (match-expansion
    (use-package foo :defines bar)


### PR DESCRIPTION
Add `:command*` keyword proposed at #851.  Special thanks to @aspiers.

This `:command*` is similar to `:command`, but it generate autoload
statement as no-interactive one.