### PR TITLE
Consistency in description of :map

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ supports this with a `:map` modifier, taking the local keymap to bind to:
 
 The effect of this statement is to wait until `helm` has loaded, and then to
 bind the key `C-c h` to `helm-execute-persistent-action` within Helm's local
-keymap, `helm-mode-map`.
+keymap, `helm-command-map`.
 
 Multiple uses of `:map` may be specified. Any binding occurring before the
 first use of `:map` are applied to the global keymap:


### PR DESCRIPTION
The code binds keys to helm-command-map and the description says helm-mode-map.  Should they should be the same map name?