### PR TITLE
Avoid positional arguments to define-minor-mode

### DIFF
--- a/bind-key.el
+++ b/bind-key.el
@@ -131,7 +131,8 @@
 
 (define-minor-mode override-global-mode
   "A minor mode so that keymap settings override other modes."
-  t "")
+  :global t
+  :lighter "")
 
 ;; the keymaps in `emulation-mode-map-alists' take precedence over
 ;; `minor-mode-map-alist'


### PR DESCRIPTION
Back in Emacs-21.1, `define-minor-mode` grew keyword arguments to
replace its old positional arguments.  Starting with Emacs-28.1
a warning will be omitted if positional arguments are still used.