### PR TITLE
Cleanup manual and regenerate use-package.texi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
-/use-package.info
 *~
-*.elc
+/*-autoloads.el
+/*.elc
+/*.html
+/*.info
+/*.pdf
+/*.texi
+/config.mk
 /dir
 /doc/content/*
+/stats/
+/use-package/

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,6 @@ help:
 	$(info make preview-manuals  - preview manuals)
 	$(info make publish-manuals  - publish manuals)
 	$(info make dist             - create tarballs)
-	$(info make bump-versions    - bump versions for release)
-	$(info make bump-snapshots   - bump versions after release)
 	@printf "\n"
 
 ## Build #############################################################
@@ -175,26 +173,3 @@ use-package-$(VERSION).tar.gz: lisp info
 	@$(CP) $(DIST_ROOT_FILES) use-package-$(VERSION)
 	@$(TAR) cz --mtime=./use-package-$(VERSION) -f use-package-$(VERSION).tar.gz use-package-$(VERSION)
 	@$(RMDIR) use-package-$(VERSION)
-
-define set_manual_version
-(let ((version (split-string "$(USE_PACKAGE_VERSION)" "\\.")))
-  (setq version (concat (car version) "." (cadr version)))
-  (dolist (file (list "use-package"))
-    (with-current-buffer (find-file-noselect (format "%s.org" file))
-      (goto-char (point-min))
-      (re-search-forward "^#\\+SUBTITLE: for version ")
-      (delete-region (point) (line-end-position))
-      (insert version)
-      (save-buffer))))
-endef
-export set_manual_version
-
-bump-versions: bump-versions-1 texi
-bump-versions-1:
-	@$(BATCH) --eval "(progn\
-        $$set_manual_version)"
-
-bump-snapshots:
-	@$(BATCH) --eval "(progn\
-        $$set_package_requires)"
-	git commit -a -m "Reset Package-Requires for Melpa"

--- a/Makefile.doc
+++ b/Makefile.doc
@@ -59,12 +59,12 @@ clean:
 # use "%.texi: %.org".  Instead we have to hardcode each file
 # using a shared target.
 
-DOC_ARGS = --batch -Q $(DOC_LOAD_PATH) -l ol-man -l ox-texinfo+.el
-DOC_EVAL = -f org-texinfo-export-to-texinfo
+ORG_ARGS = --batch -Q $(DOC_LOAD_PATH)
+ORG_EVAL = --funcall org-texinfo-export-to-texinfo
 
 texi:
 	@printf "Generating use-package.texi\n"
-	@$(EMACSBIN) $(DOC_ARGS) use-package.org $(DOC_EVAL)
+	@$(EMACSBIN) $(ORG_ARGS) use-package.org $(ORG_EVAL)
 	@echo >> use-package.texi
 
 stats:

--- a/Makefile.doc
+++ b/Makefile.doc
@@ -59,10 +59,8 @@ clean:
 # use "%.texi: %.org".  Instead we have to hardcode each file
 # using a shared target.
 
-DOC_ARGS  = --batch -Q $(DOC_LOAD_PATH)
-DOC_ARGS += -l ox-extra -l ol-man -l ox-texinfo+.el
-DOC_EVAL  = --eval "(ox-extras-activate '(ignore-headlines))"
-DOC_EVAL += -f org-texinfo-export-to-texinfo
+DOC_ARGS = --batch -Q $(DOC_LOAD_PATH) -l ol-man -l ox-texinfo+.el
+DOC_EVAL = -f org-texinfo-export-to-texinfo
 
 texi:
 	@printf "Generating use-package.texi\n"

--- a/default.mk
+++ b/default.mk
@@ -90,7 +90,4 @@ LOAD_PATH = -L $(TOP)
 
 endif # ifndef LOAD_PATH
 
-DOC_LOAD_PATH ?= $(LOAD_PATH) \
-    -L $(HOME)/emacs/site-lisp \
-    -L $(HOME)/emacs/site-lisp/ox-texinfo-plus \
-    -L $(HOME)/emacs/site-lisp/org-mode/contrib/lisp
+DOC_LOAD_PATH ?= $(LOAD_PATH) -L $(HOME)/emacs/site-lisp

--- a/use-package.org
+++ b/use-package.org
@@ -60,7 +60,6 @@ More text to come...
 :PROPERTIES:
 :EXPORT_FILE_NAME: installation
 :END:
-** _ :ignore:
 
 use-package can be installed using Emacs' package manager or manually from
 its development repository.
@@ -910,8 +909,6 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 #+END_QUOTE
 
-* _ :ignore:
-
 #  LocalWords:  ARG ARGS CONDITIONs ChangeLog DNS Dired Ediff Ediffing
 #  LocalWords:  Elpa Emacsclient FUNC Flyspell Git Git's Gitk HOOK's
 #  LocalWords:  IDENT Ido Junio LocalWords
@@ -935,7 +932,6 @@ General Public License for more details.
 # Local Variables:
 # eval: (require 'org-man     nil t)
 # eval: (require 'ox-texinfo+ nil t)
-# eval: (and (require 'ox-extra nil t) (ox-extras-activate '(ignore-headlines)))
 # indent-tabs-mode: nil
 # org-src-preserve-indentation: nil
 # End:

--- a/use-package.org
+++ b/use-package.org
@@ -846,50 +846,12 @@ As a convenience, a list of such packages may be specified:
 For more complex logic, such as that supported by ~:after~, simply use ~:if~
 and the appropriate Lisp expression.
 
-* FAQ
-:PROPERTIES:
-:APPENDIX:   t
-:EXPORT_FILE_NAME: faq
-:END:
-
-The next two nodes lists frequently asked questions.
-
-Please also use the {{{link-jump(Debugging Tools,/debugging-tools)}}}.
-
-** FAQ - How to ...?
-*** This is a question
-
-This is an answer.
-
-** FAQ - Issues and Errors
-*** This is an issues
-
-This is a description.
-
 * Debugging Tools
 :PROPERTIES:
 :EXPORT_FILE_NAME: debugging-tools
 :END:
 
 TODO
-
-Please also see the {{{link-jump(FAQ,/faq)}}}.
-
-* Command Index
-:PROPERTIES:
-:APPENDIX:   t
-:INDEX:      cp
-:END:
-* Function Index
-:PROPERTIES:
-:APPENDIX:   t
-:INDEX:      fn
-:END:
-* Variable Index
-:PROPERTIES:
-:APPENDIX:   t
-:INDEX:      vr
-:END:
 
 * _ Copying
 :PROPERTIES:

--- a/use-package.org
+++ b/use-package.org
@@ -1,4 +1,5 @@
 #+title: use-package User Manual
+:PREAMBLE:
 #+author: John Wiegley
 #+email: johnw@newartisans.com
 #+date: 2012-{{{year}}}
@@ -43,7 +44,7 @@ This document is distributed in the hope that it will be useful, but WITHOUT
 ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 #+end_quote
-
+:END:
 * Introduction
 :PROPERTIES:
 :EXPORT_FILE_NAME: _index

--- a/use-package.org
+++ b/use-package.org
@@ -1,7 +1,7 @@
 #+TITLE: use-package User Manual
 #+AUTHOR: John Wiegley
 #+EMAIL: johnw@newartisans.com
-#+DATE: 2012-2017
+#+DATE: 2012-{{{year}}}
 #+LANGUAGE: en
 
 #+HUGO_BASE_DIR: ./doc
@@ -11,7 +11,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: use-package: (use-package).
 #+TEXINFO_DIR_DESC: Declarative package configuration for Emacs.
-#+SUBTITLE: for version 2.4.1
+#+SUBTITLE: for version {{{version}}}
 
 #+OPTIONS: H:4 num:3 toc:2 creator:t
 
@@ -27,10 +27,13 @@
 
 #+MACRO: link-jump @@texinfo:@ref{$1}@@@@hugo:[$1]($2)@@
 
+#+macro: year (eval (format-time-string "%Y"))
+#+macro: version (eval (or (getenv "PACKAGE_REVDESC") (getenv "PACKAGE_VERSION") (ignore-errors (car (process-lines "git" "describe" "--exact"))) (ignore-errors (concat (car (process-lines "git" "describe" (if (getenv "AMEND") "HEAD~" "HEAD"))) "+1"))))
+
 use-package is...
 
 #+BEGIN_QUOTE
-Copyright (C) 2012-2017 John Wiegley <johnw@newartisans.com>
+Copyright (C) 2012-{{{year}}} John Wiegley <johnw@newartisans.com>
 
 You can redistribute this document and/or modify it under the terms of the GNU
 General Public License as published by the Free Software Foundation, either
@@ -894,7 +897,7 @@ Please also see the {{{link-jump(FAQ,/faq)}}}.
 :END:
 
 #+BEGIN_QUOTE
-Copyright (C) 2012-2017 John Wiegley <johnw@newartisans.com>
+Copyright (C) 2012-{{{year}}} John Wiegley <johnw@newartisans.com>
 
 You can redistribute this document and/or modify it under the terms
 of the GNU General Public License as published by the Free Software

--- a/use-package.org
+++ b/use-package.org
@@ -76,31 +76,31 @@ with it by reading the documentation in the Emacs manual, see
 
 - To use Melpa:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (require 'package)
   (add-to-list 'package-archives
                '("melpa" . "https://melpa.org/packages/") t)
-#+END_SRC
+#+end_src
 
 - To use Melpa-Stable:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (require 'package)
   (add-to-list 'package-archives
                '("melpa-stable" . "https://stable.melpa.org/packages/") t)
-#+END_SRC
+#+end_src
 
 Once you have added your preferred archive, you need to update the
 local package list using:
 
-#+BEGIN_EXAMPLE
+#+begin_example
   M-x package-refresh-contents RET
 #+END_EXAMPLE
 
 Once you have done that, you can install use-package and its dependencies
 using:
 
-#+BEGIN_EXAMPLE
+#+begin_example
   M-x package-install RET use-package RET
 #+END_EXAMPLE
 
@@ -110,27 +110,27 @@ Now see [[*Post-Installation Tasks]].
 
 First, use Git to clone the use-package repository:
 
-#+BEGIN_SRC shell-script
+#+begin_src shell-script
   $ git clone https://github.com/jwiegley/use-package.git ~/.emacs.d/site-lisp/use-package
   $ cd ~/.emacs.d/site-lisp/use-package
-#+END_SRC
+#+end_src
 
 Then compile the libraries and generate the info manuals:
 
-#+BEGIN_SRC shell-script
+#+begin_src shell-script
   $ make
-#+END_SRC
+#+end_src
 
 You may need to create ~/path/to/use-package/config.mk~ with the following
 content before running ~make~:
 
-#+BEGIN_SRC makefile
+#+begin_src makefile
   LOAD_PATH  = -L /path/to/use-package
-#+END_SRC
+#+end_src
 
 Finally add this to your init file:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (add-to-list 'load-path "~/.emacs.d/site-lisp/use-package")
   (require 'use-package)
 
@@ -138,7 +138,7 @@ Finally add this to your init file:
     (info-initialize)
     (add-to-list 'Info-directory-list
                  "~/.emacs.d/site-lisp/use-package/"))
-#+END_SRC
+#+end_src
 
 Note that elements of ~load-path~ should not end with a slash, while those of
 ~Info-directory-list~ should.
@@ -149,10 +149,10 @@ using ~sudo make install~ and setting ~load-path~ accordingly.
 
 To update use-package use:
 
-#+BEGIN_SRC shell-script
+#+begin_src shell-script
   $ git pull
   $ make
-#+END_SRC
+#+end_src
 
 At times it might be necessary to run ~make clean all~ instead.
 
@@ -166,13 +166,13 @@ After installing use-package you should verify that you are indeed using the
 use-package release you think you are using. It's best to restart Emacs before
 doing so, to make sure you are not using an outdated value for ~load-path~.
 
-#+BEGIN_EXAMPLE
+#+begin_example
   C-h v use-package-version RET
 #+END_EXAMPLE
 
 should display something like
 
-#+BEGIN_EXAMPLE
+#+begin_example
   use-package-version’s value is "2.4.1"
 #+END_EXAMPLE
 
@@ -231,7 +231,7 @@ time. This can achieved using an ~:after~ keyword that allows a fairly rich
 description of the exact conditions when loading should occur. Here is an
 example:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (use-package hydra
     :load-path "site-lisp/hydra")
 
@@ -240,7 +240,7 @@ example:
 
   (use-package ivy-hydra
     :after (ivy hydra))
-#+END_SRC
+#+end_src
 
 In this case, because all of these packages are demand-loaded in the order
 they occur, the use of ~:after~ is not strictly necessary. By using it,
@@ -251,13 +251,13 @@ By default, ~:after (foo bar)~ is the same as ~:after (:all foo bar)~, meaning
 that loading of the given package will not happen until both ~foo~ and ~bar~
 have been loaded. Here are some of the other possibilities:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   :after (foo bar)
   :after (:all foo bar)
   :after (:any foo bar)
   :after (:all (:any foo bar) (:any baz quux))
   :after (:any (:all foo bar) (:all baz quux))
-#+END_SRC
+#+end_src
 
 When you nest selectors, such as ~(:any (:all foo bar) (:all baz quux))~, it
 means that the package will be loaded when either both ~foo~ and ~bar~ have
@@ -286,21 +286,21 @@ keypress after the first load, to reinterpret that keypress as a prefix key.
 
 For example:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (use-package projectile
     :bind-keymap
     ("C-c p" . projectile-command-map)
-#+END_SRC
+#+end_src
 
 ** ~:bind~, ~:bind*~
 
 Another common thing to do when loading a module is to bind a key to primary
 commands within that module:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (use-package ace-jump-mode
     :bind ("C-." . ace-jump-mode))
-#+END_SRC
+#+end_src
 
 This does two things: first, it creates an autoload for the ~ace-jump-mode~
 command and defers loading of ~ace-jump-mode~ until you actually use it.
@@ -310,12 +310,12 @@ throughout your ~.emacs~ file.
 
 A more literal way to do the exact same thing is:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (use-package ace-jump-mode
     :commands ace-jump-mode
     :init
     (bind-key "C-." 'ace-jump-mode))
-#+END_SRC
+#+end_src
 
 When you use the ~:commands~ keyword, it creates autoloads for those commands
 and defers loading of the module until they are used. Since the ~:init~ form
@@ -324,12 +324,12 @@ to restrict ~:init~ code to only what would succeed either way.
 
 The ~:bind~ keyword takes either a cons or a list of conses:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (use-package hi-lock
     :bind (("M-o l" . highlight-lines-matching-regexp)
            ("M-o r" . highlight-regexp)
            ("M-o w" . highlight-phrase)))
-#+END_SRC
+#+end_src
 
 The ~:commands~ keyword likewise takes either a symbol or a list of symbols.
 
@@ -339,13 +339,13 @@ the "kbd" syntax: see [[https://www.gnu.org/software/emacs/manual/html_node/emac
 
 Examples:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (use-package helm
     :bind (("M-x" . helm-M-x)
            ("M-<f5>" . helm-find-files)
            ([f10] . helm-buffers-list)
            ([S-f10] . helm-recentf)))
-#+END_SRC
+#+end_src
 
 *** Binding to local keymaps
 
@@ -353,11 +353,11 @@ Slightly different from binding a key to a keymap, is binding a key *within* a
 local keymap that only exists after the package is loaded.  ~use-package~
 supports this with a ~:map~ modifier, taking the local keymap to bind to:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (use-package helm
     :bind (:map helm-command-map
            ("C-c h" . helm-execute-persistent-action)))
-#+END_SRC
+#+end_src
 
 The effect of this statement is to wait until ~helm~ has loaded, and then to
 bind the key ~C-c h~ to ~helm-execute-persistent-action~ within Helm's local
@@ -366,7 +366,7 @@ keymap, ~helm-mode-map~.
 Multiple uses of ~:map~ may be specified. Any binding occurring before the
 first use of ~:map~ are applied to the global keymap:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (use-package term
     :bind (("C-c t" . term)
            :map term-mode-map
@@ -376,14 +376,14 @@ first use of ~:map~ are applied to the global keymap:
            ("M-o" . other-window)
            ("M-p" . term-send-up)
            ("M-n" . term-send-down)))
-#+END_SRC
+#+end_src
 
 ** ~:commands~
 ** ~:preface~, ~:init~, ~:config~
 
 Here is the simplest ~use-package~ declaration:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   ;; This is only needed once, near the top of the file
   (eval-when-compile
     ;; Following line is not needed if use-package.el is in ~/.emacs.d
@@ -391,7 +391,7 @@ Here is the simplest ~use-package~ declaration:
     (require 'use-package))
 
   (use-package foo)
-#+END_SRC
+#+end_src
 
 This loads in the package ~foo~, but only if ~foo~ is available on your
 system. If not, a warning is logged to the ~*Messages*~ buffer. If it
@@ -401,27 +401,27 @@ took to load, if it took over 0.1 seconds.
 Use the ~:init~ keyword to execute code before a package is loaded.  It
 accepts one or more forms, up until the next keyword:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (use-package foo
     :init
     (setq foo-variable t))
-#+END_SRC
+#+end_src
 
 Similarly, ~:config~ can be used to execute code after a package is loaded.
 In cases where loading is done lazily (see more about autoloading below), this
 execution is deferred until after the autoload occurs:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (use-package foo
     :init
     (setq foo-variable t)
     :config
     (foo-mode 1))
-#+END_SRC
+#+end_src
 
 As you might expect, you can use ~:init~ and ~:config~ together:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (use-package color-moccur
     :commands (isearch-moccur isearch-all)
     :bind (("M-s O" . moccur)
@@ -432,7 +432,7 @@ As you might expect, you can use ~:init~ and ~:config~ together:
     (setq isearch-lazy-highlight t)
     :config
     (use-package moccur-edit))
-#+END_SRC
+#+end_src
 
 In this case, I want to autoload the commands ~isearch-moccur~ and
 ~isearch-all~ from ~color-moccur.el~, and bind keys both at the global level
@@ -444,12 +444,12 @@ loaded, to allow editing of the ~moccur~ buffer.
 
 The ~:custom~ keyword allows customization of package custom variables.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (use-package comint
     :custom
     (comint-buffer-maximum-size 20000 "Increase comint buffer size.")
     (comint-prompt-read-only t "Make the prompt read only."))
-#+END_SRC
+#+end_src
 
 The documentation string is not mandatory.
 
@@ -457,11 +457,11 @@ The documentation string is not mandatory.
 
 The ~:custom-face~ keyword allows customization of package custom faces.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (use-package eruby-mode
     :custom-face
     (eruby-standard-face ((t (:slant italic)))))
-#+END_SRC
+#+end_src
 
 ** ~:defer~, ~:demand~
 

--- a/use-package.org
+++ b/use-package.org
@@ -31,19 +31,14 @@
 #+macro: year (eval (format-time-string "%Y"))
 #+macro: version (eval (or (getenv "PACKAGE_REVDESC") (getenv "PACKAGE_VERSION") (ignore-errors (car (process-lines "git" "describe" "--exact"))) (ignore-errors (concat (car (process-lines "git" "describe" (if (getenv "AMEND") "HEAD~" "HEAD"))) "+1"))))
 
-use-package is...
+The ~use-package~ macro allows you to isolate package configuration in your
+~.emacs~ file in a way that is both performance-oriented and, well, tidy. I
+created it because I have over 80 packages that I use in Emacs, and things
+were getting difficult to manage. Yet with this utility my total load time is
+around 2 seconds, with no loss of functionality!
 
-#+begin_quote
-Copyright (C) 2012-{{{year}}} John Wiegley <johnw@newartisans.com>
+#+texinfo: @insertcopying
 
-You can redistribute this document and/or modify it under the terms of the GNU
-General Public License as published by the Free Software Foundation, either
-version 3 of the License, or (at your option) any later version.
-
-This document is distributed in the hope that it will be useful, but WITHOUT
-ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#+end_quote
 :END:
 * Introduction
 :PROPERTIES:

--- a/use-package.org
+++ b/use-package.org
@@ -13,7 +13,6 @@
 #+TEXINFO_DIR_DESC: Declarative package configuration for Emacs.
 #+SUBTITLE: for version 2.4.1
 
-#+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:3 toc:2 creator:t
 
 # Below macro is used so that both texinfo and hugo exports work
@@ -176,8 +175,7 @@ should display something like
 If you are completely new to use-package then see {{{link-jump(Getting
 Started,/getting-started)}}}.
 
-If you run into problems, then please see the
-{{{link-jump(FAQ,/faq)}}}.  Also see the {{{link-jump(Debugging
+If you run into problems, then please see the {{{link-jump(Debugging
 Tools,/debugging-tools)}}}.
 
 * Getting Started
@@ -930,8 +928,6 @@ General Public License for more details.
 #  LocalWords:  backported macOS
 
 # Local Variables:
-# eval: (require 'org-man     nil t)
-# eval: (require 'ox-texinfo+ nil t)
 # indent-tabs-mode: nil
 # org-src-preserve-indentation: nil
 # End:

--- a/use-package.org
+++ b/use-package.org
@@ -232,14 +232,14 @@ description of the exact conditions when loading should occur. Here is an
 example:
 
 #+BEGIN_SRC emacs-lisp
-(use-package hydra
-  :load-path "site-lisp/hydra")
+  (use-package hydra
+    :load-path "site-lisp/hydra")
 
-(use-package ivy
-  :load-path "site-lisp/swiper")
+  (use-package ivy
+    :load-path "site-lisp/swiper")
 
-(use-package ivy-hydra
-  :after (ivy hydra))
+  (use-package ivy-hydra
+    :after (ivy hydra))
 #+END_SRC
 
 In this case, because all of these packages are demand-loaded in the order
@@ -252,11 +252,11 @@ that loading of the given package will not happen until both ~foo~ and ~bar~
 have been loaded. Here are some of the other possibilities:
 
 #+BEGIN_SRC emacs-lisp
-:after (foo bar)
-:after (:all foo bar)
-:after (:any foo bar)
-:after (:all (:any foo bar) (:any baz quux))
-:after (:any (:all foo bar) (:all baz quux))
+  :after (foo bar)
+  :after (:all foo bar)
+  :after (:any foo bar)
+  :after (:all (:any foo bar) (:any baz quux))
+  :after (:any (:all foo bar) (:all baz quux))
 #+END_SRC
 
 When you nest selectors, such as ~(:any (:all foo bar) (:all baz quux))~, it
@@ -287,9 +287,9 @@ keypress after the first load, to reinterpret that keypress as a prefix key.
 For example:
 
 #+BEGIN_SRC emacs-lisp
-(use-package projectile
-  :bind-keymap
-  ("C-c p" . projectile-command-map)
+  (use-package projectile
+    :bind-keymap
+    ("C-c p" . projectile-command-map)
 #+END_SRC
 
 ** ~:bind~, ~:bind*~
@@ -298,8 +298,8 @@ Another common thing to do when loading a module is to bind a key to primary
 commands within that module:
 
 #+BEGIN_SRC emacs-lisp
-(use-package ace-jump-mode
-  :bind ("C-." . ace-jump-mode))
+  (use-package ace-jump-mode
+    :bind ("C-." . ace-jump-mode))
 #+END_SRC
 
 This does two things: first, it creates an autoload for the ~ace-jump-mode~
@@ -311,10 +311,10 @@ throughout your ~.emacs~ file.
 A more literal way to do the exact same thing is:
 
 #+BEGIN_SRC emacs-lisp
-(use-package ace-jump-mode
-  :commands ace-jump-mode
-  :init
-  (bind-key "C-." 'ace-jump-mode))
+  (use-package ace-jump-mode
+    :commands ace-jump-mode
+    :init
+    (bind-key "C-." 'ace-jump-mode))
 #+END_SRC
 
 When you use the ~:commands~ keyword, it creates autoloads for those commands
@@ -325,10 +325,10 @@ to restrict ~:init~ code to only what would succeed either way.
 The ~:bind~ keyword takes either a cons or a list of conses:
 
 #+BEGIN_SRC emacs-lisp
-(use-package hi-lock
-  :bind (("M-o l" . highlight-lines-matching-regexp)
-         ("M-o r" . highlight-regexp)
-         ("M-o w" . highlight-phrase)))
+  (use-package hi-lock
+    :bind (("M-o l" . highlight-lines-matching-regexp)
+           ("M-o r" . highlight-regexp)
+           ("M-o w" . highlight-phrase)))
 #+END_SRC
 
 The ~:commands~ keyword likewise takes either a symbol or a list of symbols.
@@ -340,11 +340,11 @@ the "kbd" syntax: see [[https://www.gnu.org/software/emacs/manual/html_node/emac
 Examples:
 
 #+BEGIN_SRC emacs-lisp
-(use-package helm
-  :bind (("M-x" . helm-M-x)
-         ("M-<f5>" . helm-find-files)
-         ([f10] . helm-buffers-list)
-         ([S-f10] . helm-recentf)))
+  (use-package helm
+    :bind (("M-x" . helm-M-x)
+           ("M-<f5>" . helm-find-files)
+           ([f10] . helm-buffers-list)
+           ([S-f10] . helm-recentf)))
 #+END_SRC
 
 *** Binding to local keymaps
@@ -354,9 +354,9 @@ local keymap that only exists after the package is loaded.  ~use-package~
 supports this with a ~:map~ modifier, taking the local keymap to bind to:
 
 #+BEGIN_SRC emacs-lisp
-(use-package helm
-  :bind (:map helm-command-map
-         ("C-c h" . helm-execute-persistent-action)))
+  (use-package helm
+    :bind (:map helm-command-map
+           ("C-c h" . helm-execute-persistent-action)))
 #+END_SRC
 
 The effect of this statement is to wait until ~helm~ has loaded, and then to
@@ -367,15 +367,15 @@ Multiple uses of ~:map~ may be specified. Any binding occurring before the
 first use of ~:map~ are applied to the global keymap:
 
 #+BEGIN_SRC emacs-lisp
-(use-package term
-  :bind (("C-c t" . term)
-         :map term-mode-map
-         ("M-p" . term-send-up)
-         ("M-n" . term-send-down)
-         :map term-raw-map
-         ("M-o" . other-window)
-         ("M-p" . term-send-up)
-         ("M-n" . term-send-down)))
+  (use-package term
+    :bind (("C-c t" . term)
+           :map term-mode-map
+           ("M-p" . term-send-up)
+           ("M-n" . term-send-down)
+           :map term-raw-map
+           ("M-o" . other-window)
+           ("M-p" . term-send-up)
+           ("M-n" . term-send-down)))
 #+END_SRC
 
 ** ~:commands~
@@ -384,13 +384,13 @@ first use of ~:map~ are applied to the global keymap:
 Here is the simplest ~use-package~ declaration:
 
 #+BEGIN_SRC emacs-lisp
-;; This is only needed once, near the top of the file
-(eval-when-compile
-  ;; Following line is not needed if use-package.el is in ~/.emacs.d
-  (add-to-list 'load-path "<path where use-package is installed>")
-  (require 'use-package))
+  ;; This is only needed once, near the top of the file
+  (eval-when-compile
+    ;; Following line is not needed if use-package.el is in ~/.emacs.d
+    (add-to-list 'load-path "<path where use-package is installed>")
+    (require 'use-package))
 
-(use-package foo)
+  (use-package foo)
 #+END_SRC
 
 This loads in the package ~foo~, but only if ~foo~ is available on your
@@ -402,9 +402,9 @@ Use the ~:init~ keyword to execute code before a package is loaded.  It
 accepts one or more forms, up until the next keyword:
 
 #+BEGIN_SRC emacs-lisp
-(use-package foo
-  :init
-  (setq foo-variable t))
+  (use-package foo
+    :init
+    (setq foo-variable t))
 #+END_SRC
 
 Similarly, ~:config~ can be used to execute code after a package is loaded.
@@ -412,26 +412,26 @@ In cases where loading is done lazily (see more about autoloading below), this
 execution is deferred until after the autoload occurs:
 
 #+BEGIN_SRC emacs-lisp
-(use-package foo
-  :init
-  (setq foo-variable t)
-  :config
-  (foo-mode 1))
+  (use-package foo
+    :init
+    (setq foo-variable t)
+    :config
+    (foo-mode 1))
 #+END_SRC
 
 As you might expect, you can use ~:init~ and ~:config~ together:
 
 #+BEGIN_SRC emacs-lisp
-(use-package color-moccur
-  :commands (isearch-moccur isearch-all)
-  :bind (("M-s O" . moccur)
-         :map isearch-mode-map
-         ("M-o" . isearch-moccur)
-         ("M-O" . isearch-moccur-all))
-  :init
-  (setq isearch-lazy-highlight t)
-  :config
-  (use-package moccur-edit))
+  (use-package color-moccur
+    :commands (isearch-moccur isearch-all)
+    :bind (("M-s O" . moccur)
+           :map isearch-mode-map
+           ("M-o" . isearch-moccur)
+           ("M-O" . isearch-moccur-all))
+    :init
+    (setq isearch-lazy-highlight t)
+    :config
+    (use-package moccur-edit))
 #+END_SRC
 
 In this case, I want to autoload the commands ~isearch-moccur~ and
@@ -445,10 +445,10 @@ loaded, to allow editing of the ~moccur~ buffer.
 The ~:custom~ keyword allows customization of package custom variables.
 
 #+BEGIN_SRC emacs-lisp
-(use-package comint
-  :custom
-  (comint-buffer-maximum-size 20000 "Increase comint buffer size.")
-  (comint-prompt-read-only t "Make the prompt read only."))
+  (use-package comint
+    :custom
+    (comint-buffer-maximum-size 20000 "Increase comint buffer size.")
+    (comint-prompt-read-only t "Make the prompt read only."))
 #+END_SRC
 
 The documentation string is not mandatory.
@@ -458,9 +458,9 @@ The documentation string is not mandatory.
 The ~:custom-face~ keyword allows customization of package custom faces.
 
 #+BEGIN_SRC emacs-lisp
-(use-package eruby-mode
-  :custom-face
-  (eruby-standard-face ((t (:slant italic)))))
+  (use-package eruby-mode
+    :custom-face
+    (eruby-standard-face ((t (:slant italic)))))
 #+END_SRC
 
 ** ~:defer~, ~:demand~
@@ -487,26 +487,26 @@ the ~:defines~ and ~:functions~ keywords to introduce dummy variable and
 function declarations solely for the sake of the byte-compiler:
 
 #+begin_src emacs-lisp
-(use-package texinfo
-  :defines texinfo-section-list
-  :commands texinfo-mode
-  :init
-  (add-to-list 'auto-mode-alist '("\\.texi$" . texinfo-mode)))
+  (use-package texinfo
+    :defines texinfo-section-list
+    :commands texinfo-mode
+    :init
+    (add-to-list 'auto-mode-alist '("\\.texi$" . texinfo-mode)))
 #+end_src
 
 If you need to silence a missing function warning, you can use ~:functions~:
 
 #+begin_src emacs-lisp
-(use-package ruby-mode
-  :mode "\\.rb\\'"
-  :interpreter "ruby"
-  :functions inf-ruby-keys
-  :config
-  (defun my-ruby-mode-hook ()
-    (require 'inf-ruby)
-    (inf-ruby-keys))
+  (use-package ruby-mode
+    :mode "\\.rb\\'"
+    :interpreter "ruby"
+    :functions inf-ruby-keys
+    :config
+    (defun my-ruby-mode-hook ()
+      (require 'inf-ruby)
+      (inf-ruby-keys))
 
-  (add-hook 'ruby-mode-hook 'my-ruby-mode-hook))
+    (add-hook 'ruby-mode-hook 'my-ruby-mode-hook))
 #+end_src
 
 ** ~:diminish~, ~:delight~
@@ -521,11 +521,11 @@ replacement string, in which case the minor mode symbol is guessed to be the
 package name with "-mode" appended at the end:
 
 #+begin_src emacs-lisp
-(use-package abbrev
-  :diminish abbrev-mode
-  :config
-  (if (file-exists-p abbrev-file-name)
-      (quietly-read-abbrev-file)))
+  (use-package abbrev
+    :diminish abbrev-mode
+    :config
+    (if (file-exists-p abbrev-file-name)
+        (quietly-read-abbrev-file)))
 #+end_src
 
 [[https://elpa.gnu.org/packages/delight.html][delight]] is invoked with the ~:delight~ keyword, which is passed a minor mode
@@ -535,24 +535,24 @@ end), both of these, or several lists of both. If no arguments are provided,
 the default mode name is hidden completely.
 
 #+begin_src emacs-lisp
-;; Don't show anything for rainbow-mode.
-(use-package rainbow-mode
-  :delight)
+  ;; Don't show anything for rainbow-mode.
+  (use-package rainbow-mode
+    :delight)
 
-;; Don't show anything for auto-revert-mode, which doesn't match
-;; its package name.
-(use-package autorevert
-  :delight auto-revert-mode)
+  ;; Don't show anything for auto-revert-mode, which doesn't match
+  ;; its package name.
+  (use-package autorevert
+    :delight auto-revert-mode)
 
-;; Remove the mode name for projectile-mode, but show the project name.
-(use-package projectile
-  :delight '(:eval (concat " " (projectile-project-name))))
+  ;; Remove the mode name for projectile-mode, but show the project name.
+  (use-package projectile
+    :delight '(:eval (concat " " (projectile-project-name))))
 
-;; Completely hide visual-line-mode and change auto-fill-mode to " AF".
-(use-package emacs
-  :delight
-  (auto-fill-function " AF")
-  (visual-line-mode))
+  ;; Completely hide visual-line-mode and change auto-fill-mode to " AF".
+  (use-package emacs
+    :delight
+    (auto-fill-function " AF")
+    (visual-line-mode))
 #+end_src
 
 ** ~:disabled~
@@ -561,9 +561,9 @@ The ~:disabled~ keyword can turn off a module you're having difficulties with,
 or stop loading something you're not using at the present time:
 
 #+begin_src emacs-lisp
-(use-package ess-site
-  :disabled
-  :commands R)
+  (use-package ess-site
+    :disabled
+    :commands R)
 #+end_src
 
 When byte-compiling your ~.emacs~ file, disabled declarations are omitted
@@ -579,16 +579,16 @@ not already present on your system (set ~(setq use-package-always-ensure t)~
 if you wish this behavior to be global for all packages):
 
 #+begin_src emacs-lisp
-(use-package magit
-  :ensure t)
+  (use-package magit
+    :ensure t)
 #+end_src
 
 If you need to install a different package from the one named by
 ~use-package~, you can specify it like this:
 
 #+begin_src emacs-lisp
-(use-package tex
-  :ensure auctex)
+  (use-package tex
+    :ensure auctex)
 #+end_src
 
 Lastly, when running on Emacs 24.4 or later, use-package can pin a package to
@@ -619,25 +619,25 @@ Archive 'foo' requested for package 'bar' is not available.
 Example:
 
 #+begin_src emacs-lisp
-(use-package company
-  :ensure t
-  :pin melpa-stable)
+  (use-package company
+    :ensure t
+    :pin melpa-stable)
 
-(use-package evil
-  :ensure t)
-  ;; no :pin needed, as package.el will choose the version in melpa
+  (use-package evil
+    :ensure t)
+    ;; no :pin needed, as package.el will choose the version in melpa
 
-(use-package adaptive-wrap
-  :ensure t
-  ;; as this package is available only in the gnu archive, this is
-  ;; technically not needed, but it helps to highlight where it
-  ;; comes from
-  :pin gnu)
+  (use-package adaptive-wrap
+    :ensure t
+    ;; as this package is available only in the gnu archive, this is
+    ;; technically not needed, but it helps to highlight where it
+    ;; comes from
+    :pin gnu)
 
-(use-package org
-  :ensure t
-  ;; ignore org-mode from upstream and use a manually installed version
-  :pin manual)
+  (use-package org
+    :ensure t
+    ;; ignore org-mode from upstream and use a manually installed version
+    :pin manual)
 #+end_src
 
 *NOTE*: the ~:pin~ argument has no effect on emacs versions < 24.4.
@@ -648,37 +648,37 @@ The ~:hook~ keyword allows adding functions onto hooks, here only the basename
 of the hook is required. Thus, all of the following are equivalent:
 
 #+begin_src emacs-lisp
-(use-package ace-jump-mode
-  :hook prog-mode)
+  (use-package ace-jump-mode
+    :hook prog-mode)
 
-(use-package ace-jump-mode
-  :hook (prog-mode . ace-jump-mode))
+  (use-package ace-jump-mode
+    :hook (prog-mode . ace-jump-mode))
 
-(use-package ace-jump-mode
-  :commands ace-jump-mode
-  :init
-  (add-hook 'prog-mode-hook #'ace-jump-mode))
+  (use-package ace-jump-mode
+    :commands ace-jump-mode
+    :init
+    (add-hook 'prog-mode-hook #'ace-jump-mode))
 #+end_src
 
 And likewise, when multiple hooks should be applied, the following are also
 equivalent:
 
 #+begin_src emacs-lisp
-(use-package ace-jump-mode
-  :hook (prog-mode text-mode))
+  (use-package ace-jump-mode
+    :hook (prog-mode text-mode))
 
-(use-package ace-jump-mode
-  :hook ((prog-mode text-mode) . ace-jump-mode))
+  (use-package ace-jump-mode
+    :hook ((prog-mode text-mode) . ace-jump-mode))
 
-(use-package ace-jump-mode
-  :hook ((prog-mode . ace-jump-mode)
-         (text-mode . ace-jump-mode)))
+  (use-package ace-jump-mode
+    :hook ((prog-mode . ace-jump-mode)
+           (text-mode . ace-jump-mode)))
 
-(use-package ace-jump-mode
-  :commands ace-jump-mode
-  :init
-  (add-hook 'prog-mode-hook #'ace-jump-mode)
-  (add-hook 'text-mode-hook #'ace-jump-mode))
+  (use-package ace-jump-mode
+    :commands ace-jump-mode
+    :init
+    (add-hook 'prog-mode-hook #'ace-jump-mode)
+    (add-hook 'text-mode-hook #'ace-jump-mode))
 #+end_src
 
 The use of ~:hook~, as with ~:bind~, ~:mode~, ~:interpreter~, etc., causes the
@@ -695,21 +695,21 @@ For example, I only want ~edit-server~ running for my main, graphical Emacs,
 not for other Emacsen I may start at the command line:
 
 #+begin_src emacs-lisp
-(use-package edit-server
-  :if window-system
-  :init
-  (add-hook 'after-init-hook 'server-start t)
-  (add-hook 'after-init-hook 'edit-server-start t))
+  (use-package edit-server
+    :if window-system
+    :init
+    (add-hook 'after-init-hook 'server-start t)
+    (add-hook 'after-init-hook 'edit-server-start t))
 #+end_src
 
 In another example, we can load things conditional on the operating system:
 
 #+begin_src emacs-lisp
-(use-package exec-path-from-shell
-  :if (memq window-system '(mac ns))
-  :ensure t
-  :config
-  (exec-path-from-shell-initialize))
+  (use-package exec-path-from-shell
+    :if (memq window-system '(mac ns))
+    :ensure t
+    :config
+    (exec-path-from-shell-initialize))
 #+end_src
 
 Note that ~:when~ is provided as an alias for ~:if~, and ~:unless foo~ means
@@ -723,9 +723,9 @@ strings. If the path is relative, it is expanded within
 ~user-emacs-directory~:
 
 #+begin_src emacs-lisp
-(use-package ess-site
-  :load-path "site-lisp/ess/lisp/"
-  :commands R)
+  (use-package ess-site
+    :load-path "site-lisp/ess/lisp/"
+    :commands R)
 #+end_src
 
 Note that when using a symbol or a function to provide a dynamically generated
@@ -736,13 +736,13 @@ value is fixed at whatever was determined during compilation, to avoid looking
 up the same information again on each startup:
 
 #+begin_src emacs-lisp
-(eval-and-compile
-  (defun ess-site-load-path ()
-    (shell-command "find ~ -path ess/lisp")))
+  (eval-and-compile
+    (defun ess-site-load-path ()
+      (shell-command "find ~ -path ess/lisp")))
 
-(use-package ess-site
-  :load-path (lambda () (list (ess-site-load-path)))
-  :commands R)
+  (use-package ess-site
+    :load-path (lambda () (list (ess-site-load-path)))
+    :commands R)
 #+end_src
 
 ** ~:mode~, ~:interpreter~
@@ -753,14 +753,14 @@ variables. The specifier to either keyword can be a cons cell, a list of cons
 cells, or a string or regexp:
 
 #+begin_src emacs-lisp
-(use-package ruby-mode
-  :mode "\\.rb\\'"
-  :interpreter "ruby")
+  (use-package ruby-mode
+    :mode "\\.rb\\'"
+    :interpreter "ruby")
 
-;; The package is "python" but the mode is "python-mode":
-(use-package python
-  :mode ("\\.py\\'" . python-mode)
-  :interpreter ("python" . python-mode))
+  ;; The package is "python" but the mode is "python-mode":
+  (use-package python
+    :mode ("\\.py\\'" . python-mode)
+    :interpreter ("python" . python-mode))
 #+end_src
 
 If you aren't using ~:commands~, ~:bind~, ~:bind*~, ~:bind-keymap~,
@@ -769,18 +769,18 @@ the docstring for ~use-package~ for a brief description of each), you can
 still defer loading with the ~:defer~ keyword:
 
 #+begin_src emacs-lisp
-(use-package ace-jump-mode
-  :defer t
-  :init
-  (autoload 'ace-jump-mode "ace-jump-mode" nil t)
-  (bind-key "C-." 'ace-jump-mode))
+  (use-package ace-jump-mode
+    :defer t
+    :init
+    (autoload 'ace-jump-mode "ace-jump-mode" nil t)
+    (bind-key "C-." 'ace-jump-mode))
 #+end_src
 
 This does exactly the same thing as the following:
 
 #+begin_src emacs-lisp
-(use-package ace-jump-mode
-  :bind ("C-." . ace-jump-mode))
+  (use-package ace-jump-mode
+    :bind ("C-." . ace-jump-mode))
 #+end_src
 
 ** ~:magic~, ~:magic-fallback~
@@ -791,11 +791,11 @@ file matches a given regular expression. The difference between the two is
 that ~:magic-fallback~ has a lower priority than ~:mode~. For example:
 
 #+begin_src emacs-lisp
-(use-package pdf-tools
-  :load-path "site-lisp/pdf-tools/lisp"
-  :magic ("%PDF" . pdf-view-mode)
-  :config
-  (pdf-tools-install))
+  (use-package pdf-tools
+    :load-path "site-lisp/pdf-tools/lisp"
+    :magic ("%PDF" . pdf-view-mode)
+    :config
+    (pdf-tools-install))
 #+end_src
 
 This registers an autoloaded command for ~pdf-view-mode~, defers loading of
@@ -812,10 +812,10 @@ package may have special loading requirements, and all that you want to use
 such cases, use the ~:no-require~ keyword:
 
 #+begin_src emacs-lisp
-(use-package foo
-  :no-require t
-  :config
-  (message "This is evaluated when `foo' is loaded"))
+  (use-package foo
+    :no-require t
+    :config
+    (message "This is evaluated when `foo' is loaded"))
 #+end_src
 
 ** ~:requires~
@@ -827,22 +827,22 @@ encountered. By "available" in this context it means that ~foo~ is available
 of ~(featurep 'foo)~ evaluates to a non-nil value. For example:
 
 #+begin_src emacs-lisp
-(use-package abbrev
-  :requires foo)
+  (use-package abbrev
+    :requires foo)
 #+end_src
 
 This is the same as:
 
 #+begin_src emacs-lisp
-(use-package abbrev
-  :if (featurep 'foo))
+  (use-package abbrev
+    :if (featurep 'foo))
 #+end_src
 
 As a convenience, a list of such packages may be specified:
 
 #+begin_src emacs-lisp
-(use-package abbrev
-  :requires (foo bar baz))
+  (use-package abbrev
+    :requires (foo bar baz))
 #+end_src
 
 For more complex logic, such as that supported by ~:after~, simply use ~:if~

--- a/use-package.org
+++ b/use-package.org
@@ -1,19 +1,19 @@
-#+TITLE: use-package User Manual
-#+AUTHOR: John Wiegley
-#+EMAIL: johnw@newartisans.com
-#+DATE: 2012-{{{year}}}
-#+LANGUAGE: en
+#+title: use-package User Manual
+#+author: John Wiegley
+#+email: johnw@newartisans.com
+#+date: 2012-{{{year}}}
+#+language: en
 
-#+HUGO_BASE_DIR: ./doc
-#+HUGO_SECTION: /
-#+HUGO_MENU: :menu main
+#+hugo_base_dir: ./doc
+#+hugo_section: /
+#+hugo_menu: :menu main
 
-#+TEXINFO_DIR_CATEGORY: Emacs
-#+TEXINFO_DIR_TITLE: use-package: (use-package).
-#+TEXINFO_DIR_DESC: Declarative package configuration for Emacs.
-#+SUBTITLE: for version {{{version}}}
+#+texinfo_dir_category: Emacs
+#+texinfo_dir_title: use-package: (use-package).
+#+texinfo_dir_desc: Declarative package configuration for Emacs.
+#+subtitle: for version {{{version}}}
 
-#+OPTIONS: H:4 num:3 toc:2 creator:t
+#+options: H:4 num:3 toc:2 creator:t
 
 # Below macro is used so that both texinfo and hugo exports work
 # harmoniously.  For texinfo exports, the export is done using the
@@ -25,14 +25,14 @@
 # FIXME: This is just a workaround.. hope to get a better solution in
 # the future.
 
-#+MACRO: link-jump @@texinfo:@ref{$1}@@@@hugo:[$1]($2)@@
+#+macro: link-jump @@texinfo:@ref{$1}@@@@hugo:[$1]($2)@@
 
 #+macro: year (eval (format-time-string "%Y"))
 #+macro: version (eval (or (getenv "PACKAGE_REVDESC") (getenv "PACKAGE_VERSION") (ignore-errors (car (process-lines "git" "describe" "--exact"))) (ignore-errors (concat (car (process-lines "git" "describe" (if (getenv "AMEND") "HEAD~" "HEAD"))) "+1"))))
 
 use-package is...
 
-#+BEGIN_QUOTE
+#+begin_quote
 Copyright (C) 2012-{{{year}}} John Wiegley <johnw@newartisans.com>
 
 You can redistribute this document and/or modify it under the terms of the GNU
@@ -42,7 +42,7 @@ version 3 of the License, or (at your option) any later version.
 This document is distributed in the hope that it will be useful, but WITHOUT
 ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#+END_QUOTE
+#+end_quote
 
 * Introduction
 :PROPERTIES:
@@ -484,17 +484,17 @@ However, there are times when this is just not enough.  For those times, use
 the ~:defines~ and ~:functions~ keywords to introduce dummy variable and
 function declarations solely for the sake of the byte-compiler:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (use-package texinfo
   :defines texinfo-section-list
   :commands texinfo-mode
   :init
   (add-to-list 'auto-mode-alist '("\\.texi$" . texinfo-mode)))
-#+END_SRC
+#+end_src
 
 If you need to silence a missing function warning, you can use ~:functions~:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (use-package ruby-mode
   :mode "\\.rb\\'"
   :interpreter "ruby"
@@ -505,7 +505,7 @@ If you need to silence a missing function warning, you can use ~:functions~:
     (inf-ruby-keys))
 
   (add-hook 'ruby-mode-hook 'my-ruby-mode-hook))
-#+END_SRC
+#+end_src
 
 ** ~:diminish~, ~:delight~
 
@@ -518,13 +518,13 @@ minor mode symbol, a cons of the symbol and its replacement string, or just a
 replacement string, in which case the minor mode symbol is guessed to be the
 package name with "-mode" appended at the end:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (use-package abbrev
   :diminish abbrev-mode
   :config
   (if (file-exists-p abbrev-file-name)
       (quietly-read-abbrev-file)))
-#+END_SRC
+#+end_src
 
 [[https://elpa.gnu.org/packages/delight.html][delight]] is invoked with the ~:delight~ keyword, which is passed a minor mode
 symbol, a replacement string or quoted [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Mode-Line-Data.html][mode-line data]] (in which case the minor
@@ -532,7 +532,7 @@ mode symbol is guessed to be the package name with "-mode" appended at the
 end), both of these, or several lists of both. If no arguments are provided,
 the default mode name is hidden completely.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 ;; Don't show anything for rainbow-mode.
 (use-package rainbow-mode
   :delight)
@@ -551,18 +551,18 @@ the default mode name is hidden completely.
   :delight
   (auto-fill-function " AF")
   (visual-line-mode))
-#+END_SRC
+#+end_src
 
 ** ~:disabled~
 
 The ~:disabled~ keyword can turn off a module you're having difficulties with,
 or stop loading something you're not using at the present time:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (use-package ess-site
   :disabled
   :commands R)
-#+END_SRC
+#+end_src
 
 When byte-compiling your ~.emacs~ file, disabled declarations are omitted
 from the output entirely, to accelerate startup times.
@@ -576,18 +576,18 @@ The ~:ensure~ keyword causes the package(s) to be installed automatically if
 not already present on your system (set ~(setq use-package-always-ensure t)~
 if you wish this behavior to be global for all packages):
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (use-package magit
   :ensure t)
-#+END_SRC
+#+end_src
 
 If you need to install a different package from the one named by
 ~use-package~, you can specify it like this:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (use-package tex
   :ensure auctex)
-#+END_SRC
+#+end_src
 
 Lastly, when running on Emacs 24.4 or later, use-package can pin a package to
 a specific archive, allowing you to mix and match packages from different
@@ -610,13 +610,13 @@ name, will Just Work(tm).
 has not been configured using ~package-archives~ (apart from the magic
 ~manual~ archive mentioned above):
 
-#+BEGIN_SRC text-mode
+#+begin_src text-mode
 Archive 'foo' requested for package 'bar' is not available.
-#+END_SRC
+#+end_src
 
 Example:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (use-package company
   :ensure t
   :pin melpa-stable)
@@ -636,7 +636,7 @@ Example:
   :ensure t
   ;; ignore org-mode from upstream and use a manually installed version
   :pin manual)
-#+END_SRC
+#+end_src
 
 *NOTE*: the ~:pin~ argument has no effect on emacs versions < 24.4.
 
@@ -645,7 +645,7 @@ Example:
 The ~:hook~ keyword allows adding functions onto hooks, here only the basename
 of the hook is required. Thus, all of the following are equivalent:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (use-package ace-jump-mode
   :hook prog-mode)
 
@@ -656,12 +656,12 @@ of the hook is required. Thus, all of the following are equivalent:
   :commands ace-jump-mode
   :init
   (add-hook 'prog-mode-hook #'ace-jump-mode))
-#+END_SRC
+#+end_src
 
 And likewise, when multiple hooks should be applied, the following are also
 equivalent:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (use-package ace-jump-mode
   :hook (prog-mode text-mode))
 
@@ -677,7 +677,7 @@ equivalent:
   :init
   (add-hook 'prog-mode-hook #'ace-jump-mode)
   (add-hook 'text-mode-hook #'ace-jump-mode))
-#+END_SRC
+#+end_src
 
 The use of ~:hook~, as with ~:bind~, ~:mode~, ~:interpreter~, etc., causes the
 functions being hooked to implicitly be read as ~:commands~ (meaning they will
@@ -692,23 +692,23 @@ modules.
 For example, I only want ~edit-server~ running for my main, graphical Emacs,
 not for other Emacsen I may start at the command line:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (use-package edit-server
   :if window-system
   :init
   (add-hook 'after-init-hook 'server-start t)
   (add-hook 'after-init-hook 'edit-server-start t))
-#+END_SRC
+#+end_src
 
 In another example, we can load things conditional on the operating system:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (use-package exec-path-from-shell
   :if (memq window-system '(mac ns))
   :ensure t
   :config
   (exec-path-from-shell-initialize))
-#+END_SRC
+#+end_src
 
 Note that ~:when~ is provided as an alias for ~:if~, and ~:unless foo~ means
 the same thing as ~:if (not foo)~.
@@ -720,11 +720,11 @@ use ~:load-path~. This takes a symbol, a function, a string or a list of
 strings. If the path is relative, it is expanded within
 ~user-emacs-directory~:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (use-package ess-site
   :load-path "site-lisp/ess/lisp/"
   :commands R)
-#+END_SRC
+#+end_src
 
 Note that when using a symbol or a function to provide a dynamically generated
 list of paths, you must inform the byte-compiler of this definition so the
@@ -733,7 +733,7 @@ form ~eval-and-compile~ (as opposed to ~eval-when-compile~). Further, this
 value is fixed at whatever was determined during compilation, to avoid looking
 up the same information again on each startup:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (eval-and-compile
   (defun ess-site-load-path ()
     (shell-command "find ~ -path ess/lisp")))
@@ -741,7 +741,7 @@ up the same information again on each startup:
 (use-package ess-site
   :load-path (lambda () (list (ess-site-load-path)))
   :commands R)
-#+END_SRC
+#+end_src
 
 ** ~:mode~, ~:interpreter~
 
@@ -750,7 +750,7 @@ deferred binding within the ~auto-mode-alist~ and ~interpreter-mode-alist~
 variables. The specifier to either keyword can be a cons cell, a list of cons
 cells, or a string or regexp:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (use-package ruby-mode
   :mode "\\.rb\\'"
   :interpreter "ruby")
@@ -759,27 +759,27 @@ cells, or a string or regexp:
 (use-package python
   :mode ("\\.py\\'" . python-mode)
   :interpreter ("python" . python-mode))
-#+END_SRC
+#+end_src
 
 If you aren't using ~:commands~, ~:bind~, ~:bind*~, ~:bind-keymap~,
 ~:bind-keymap*~, ~:mode~, or ~:interpreter~ (all of which imply ~:defer~; see
 the docstring for ~use-package~ for a brief description of each), you can
 still defer loading with the ~:defer~ keyword:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (use-package ace-jump-mode
   :defer t
   :init
   (autoload 'ace-jump-mode "ace-jump-mode" nil t)
   (bind-key "C-." 'ace-jump-mode))
-#+END_SRC
+#+end_src
 
 This does exactly the same thing as the following:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (use-package ace-jump-mode
   :bind ("C-." . ace-jump-mode))
-#+END_SRC
+#+end_src
 
 ** ~:magic~, ~:magic-fallback~
 
@@ -788,13 +788,13 @@ Similar to ~:mode~ and ~:interpreter~, you can also use ~:magic~ and
 file matches a given regular expression. The difference between the two is
 that ~:magic-fallback~ has a lower priority than ~:mode~. For example:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (use-package pdf-tools
   :load-path "site-lisp/pdf-tools/lisp"
   :magic ("%PDF" . pdf-view-mode)
   :config
   (pdf-tools-install))
-#+END_SRC
+#+end_src
 
 This registers an autoloaded command for ~pdf-view-mode~, defers loading of
 ~pdf-tools~, and runs ~pdf-view-mode~ if the beginning of a buffer matches the
@@ -809,12 +809,12 @@ package may have special loading requirements, and all that you want to use
 ~use-package~ for is to add a configuration to the ~eval-after-load~ hook. In
 such cases, use the ~:no-require~ keyword:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (use-package foo
   :no-require t
   :config
   (message "This is evaluated when `foo' is loaded"))
-#+END_SRC
+#+end_src
 
 ** ~:requires~
 
@@ -824,24 +824,24 @@ dependencies are not available at the time the ~use-package~ declaration is
 encountered. By "available" in this context it means that ~foo~ is available
 of ~(featurep 'foo)~ evaluates to a non-nil value. For example:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (use-package abbrev
   :requires foo)
-#+END_SRC
+#+end_src
 
 This is the same as:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (use-package abbrev
   :if (featurep 'foo))
-#+END_SRC
+#+end_src
 
 As a convenience, a list of such packages may be specified:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (use-package abbrev
   :requires (foo bar baz))
-#+END_SRC
+#+end_src
 
 For more complex logic, such as that supported by ~:after~, simply use ~:if~
 and the appropriate Lisp expression.
@@ -896,7 +896,7 @@ Please also see the {{{link-jump(FAQ,/faq)}}}.
 :COPYING:    t
 :END:
 
-#+BEGIN_QUOTE
+#+begin_quote
 Copyright (C) 2012-{{{year}}} John Wiegley <johnw@newartisans.com>
 
 You can redistribute this document and/or modify it under the terms
@@ -908,7 +908,7 @@ This document is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
-#+END_QUOTE
+#+end_quote
 
 #  LocalWords:  ARG ARGS CONDITIONs ChangeLog DNS Dired Ediff Ediffing
 #  LocalWords:  Elpa Emacsclient FUNC Flyspell Git Git's Gitk HOOK's

--- a/use-package.org
+++ b/use-package.org
@@ -195,22 +195,23 @@ TODO. For now, see ~README.md~.
 design in various ways. Understanding these reasons may help make some of
 those decisions clearer:
 
-  1. To gather all configuration details of a package into one place, making
-     it easier to copy, disable, or move it elsewhere in the init file.
+- To gather all configuration details of a package into one place,
+  making it easier to copy, disable, or move it elsewhere in the init
+  file.
 
-  2. To reduce duplication and boilerplate, capturing several common practices
-     as mere keywords both easy and intuitive to use.
+- To reduce duplication and boilerplate, capturing several common
+  practices as mere keywords both easy and intuitive to use.
 
-  3. To make startup time of Emacs as quick as possible, without sacrificing
-     the quantity of add-on packages used.
+- To make startup time of Emacs as quick as possible, without
+  sacrificing the quantity of add-on packages used.
 
-  4. To make it so errors encountered during startup disable only the package
-     raising the error, and as little else as possible, leaving a close to a
-     functional Emacs as possible.
+- To make it so errors encountered during startup disable only the
+  package raising the error, and as little else as possible, leaving a
+  close to a functional Emacs as possible.
 
-  5. To allow byte-compilation of one's init file so that any warnings or
-     errors seen are meaningful. In this way, even if byte-compilation is not
-     used for speed (reason 3), it can still be used as a sanity check.
+- To allow byte-compilation of one's init file so that any warnings or
+  errors seen are meaningful. In this way, even if byte-compilation is not
+  used for speed (reason 3), it can still be used as a sanity check.
 
 * Issues/Requests
 :PROPERTIES:

--- a/use-package.org
+++ b/use-package.org
@@ -13,7 +13,7 @@
 #+texinfo_dir_desc: Declarative package configuration for Emacs.
 #+subtitle: for version {{{version}}}
 
-#+options: H:4 num:3 toc:2 creator:t
+#+options: H:4 num:3 toc:2
 
 # Below macro is used so that both texinfo and hugo exports work
 # harmoniously.  For texinfo exports, the export is done using the

--- a/use-package.texi
+++ b/use-package.texi
@@ -8,7 +8,7 @@
 
 @copying
 @quotation
-Copyright (C) 2012-2017 John Wiegley <johnw@@newartisans.com>
+Copyright (C) 2012-2022 John Wiegley <johnw@@newartisans.com>
 
 You can redistribute this document and/or modify it under the terms
 of the GNU General Public License as published by the Free Software
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title use-package User Manual
-@subtitle for version 2.4.1
+@subtitle for version 2.4.1-81-gb185c6b+1
 @author John Wiegley
 @page
 @vskip 0pt plus 1filll
@@ -44,20 +44,13 @@ General Public License for more details.
 @node Top
 @top use-package User Manual
 
-use-package is@dots{}
+The @code{use-package} macro allows you to isolate package configuration in your
+@code{.emacs} file in a way that is both performance-oriented and, well, tidy. I
+created it because I have over 80 packages that I use in Emacs, and things
+were getting difficult to manage. Yet with this utility my total load time is
+around 2 seconds, with no loss of functionality!
 
-@quotation
-Copyright (C) 2012-2017 John Wiegley <johnw@@newartisans.com>
-
-You can redistribute this document and/or modify it under the terms of the GNU
-General Public License as published by the Free Software Foundation, either
-version 3 of the License, or (at your option) any later version.
-
-This document is distributed in the hope that it will be useful, but WITHOUT
-ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-FOR A PARTICULAR PURPOSE@. See the GNU General Public License for more details.
-
-@end quotation
+@insertcopying
 @end ifnottex
 
 @menu
@@ -67,11 +60,7 @@ FOR A PARTICULAR PURPOSE@. See the GNU General Public License for more details.
 * Basic Concepts::
 * Issues/Requests::
 * Keywords::
-* FAQ::
 * Debugging Tools::
-* Command Index::
-* Function Index::
-* Variable Index::
 
 @detailmenu
 --- The Detailed Node Listing ---
@@ -109,21 +98,6 @@ Keywords
 * Binding to local keymaps::
 
 
-FAQ
-
-* FAQ - How to @dots{}?::
-* FAQ - Issues and Errors::
-
-FAQ - How to @dots{}?
-
-* This is a question::
-
-
-FAQ - Issues and Errors
-
-* This is an issues::
-
-
 @end detailmenu
 @end menu
 
@@ -140,12 +114,6 @@ More text to come@dots{}
 
 @node Installation
 @chapter Installation
-
-@menu
-* Installing from an Elpa Archive::
-* Installing from the Git Repository::
-* Post-Installation Tasks::
-@end menu
 
 use-package can be installed using Emacs' package manager or manually from
 its development repository.
@@ -276,8 +244,7 @@ use-package-version’s value is "2.4.1"
 
 If you are completely new to use-package then see @ref{Getting Started}.
 
-If you run into problems, then please see the
-@ref{FAQ}.  Also see the @ref{Debugging Tools}.
+If you run into problems, then please see the @ref{Debugging Tools}.
 
 @node Getting Started
 @chapter Getting Started
@@ -293,25 +260,22 @@ those decisions clearer:
 
 @itemize
 @item
-To gather all configuration details of a package into one place, making
-it easier to copy, disable, or move it elsewhere in the init file.
-
-
-@item
-To reduce duplication and boilerplate, capturing several common practices
-as mere keywords both easy and intuitive to use.
-
+To gather all configuration details of a package into one place,
+making it easier to copy, disable, or move it elsewhere in the init
+file.
 
 @item
-To make startup time of Emacs as quick as possible, without sacrificing
-the quantity of add-on packages used.
-
+To reduce duplication and boilerplate, capturing several common
+practices as mere keywords both easy and intuitive to use.
 
 @item
-To make it so errors encountered during startup disable only the package
-raising the error, and as little else as possible, leaving a close to a
-functional Emacs as possible.
+To make startup time of Emacs as quick as possible, without
+sacrificing the quantity of add-on packages used.
 
+@item
+To make it so errors encountered during startup disable only the
+package raising the error, and as little else as possible, leaving a
+close to a functional Emacs as possible.
 
 @item
 To allow byte-compilation of one's init file so that any warnings or
@@ -997,63 +961,9 @@ As a convenience, a list of such packages may be specified:
 For more complex logic, such as that supported by @code{:after}, simply use @code{:if}
 and the appropriate Lisp expression.
 
-@node FAQ
-@appendix FAQ
-
-The next two nodes lists frequently asked questions.
-
-Please also use the @ref{Debugging Tools}.
-
-@menu
-* FAQ - How to @dots{}?::
-* FAQ - Issues and Errors::
-@end menu
-
-@node FAQ - How to @dots{}?
-@appendixsec FAQ - How to @dots{}?
-
-@menu
-* This is a question::
-@end menu
-
-@node This is a question
-@appendixsubsec This is a question
-
-This is an answer.
-
-@node FAQ - Issues and Errors
-@appendixsec FAQ - Issues and Errors
-
-@menu
-* This is an issues::
-@end menu
-
-@node This is an issues
-@appendixsubsec This is an issues
-
-This is a description.
-
 @node Debugging Tools
 @chapter Debugging Tools
 
 TODO
 
-Please also see the @ref{FAQ}.
-
-@node Command Index
-@appendix Command Index
-
-@printindex cp
-
-@node Function Index
-@appendix Function Index
-
-@printindex fn
-
-@node Variable Index
-@appendix Variable Index
-
-@printindex vr
-
-Emacs 28.0.92 (Org mode 9.5.2)
 @bye


### PR DESCRIPTION
I originally added the manual and just had another look.  There was a lot of cruft laying around and I removed that.

The texi file also had not been regenerated in a while.

Due to the cleanup it should now be possible for everyone to update the texi file by running `make texi` or if the intention is to amend to the current head commit, then `AMEND=t make texi`.