### PR TITLE
Bind keys repeat map

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,87 @@ first use of `:map` are applied to the global keymap:
          ("M-p" . term-send-up)
          ("M-n" . term-send-down)))
 ```
+### Binding to repeat-maps
+
+A special case of binding within a local keymap is when that keymap is
+used by `repeat-mode`. These keymaps are usually defined specifically
+for this. Using the `:repeat-map` keyword, and passing it a name for
+the map it defines, will bind all following keys inside that map, and
+(by default) set the `repeat-map` property of each bound command to
+that map.
+
+
+This creates a keymap called `git-gutter+-repeat-map`, makes four
+bindings in it as above, then sets the `repeat-map` property of each
+bound command (`git-gutter+-next-hunk` `git-gutter+-previous-hunk`,
+`git-gutter+-stage-hunks` and `git-gutter+-revert-hunk`) to that
+keymap.
+
+``` elisp
+(use-package git-gutter+
+  :bind
+  (:repeat-map git-gutter+-repeat-map
+   ("n" . git-gutter+-next-hunk)
+   ("p" . git-gutter+-previous-hunk)
+   ("s" . git-gutter+-stage-hunks)
+   ("r" . git-gutter+-revert-hunk)))
+```
+
+Specifying `:exit` inside the scope of `:repeat-map` will prevent the
+`repeat-map` property being set, so that the command can be used from
+within the repeat map, but after it using it the repeat map will no
+longer be available. This is useful for commands often used at the end
+of a series of repeated commands:
+
+``` elisp
+(use-package git-gutter+
+  :bind
+  (:repeat-map my/git-gutter+-repeat-map
+   ("n" . git-gutter+-next-hunk)
+   ("p" . git-gutter+-previous-hunk)
+   ("s" . git-gutter+-stage-hunks)
+   ("r" . git-gutter+-revert-hunk)
+   :exit
+   ("c" . magit-commit-create)
+   ("C" . magit-commit)
+   ("b" . magit-blame)))
+```
+
+Specifying `:continue` *forces* setting the `repeat-map` property
+(just like *not* specifying `:exit`), so these two snippets are
+equivalent:
+
+``` elisp
+(use-package git-gutter+
+  :bind
+  (:repeat-map my/git-gutter+-repeat-map
+   ("n" . git-gutter+-next-hunk)
+   ("p" . git-gutter+-previous-hunk)
+   ("s" . git-gutter+-stage-hunks)
+   ("r" . git-gutter+-revert-hunk)
+   :exit
+   ("c" . magit-commit-create)
+   ("C" . magit-commit)
+   ("b" . magit-blame)))
+```
+
+``` elisp
+(use-package git-gutter+
+  :bind
+  (:repeat-map my/git-gutter+-repeat-map
+   :exit
+   ("c" . magit-commit-create)
+   ("C" . magit-commit)
+   ("b" . magit-blame)
+   :continue
+   ("n" . git-gutter+-next-hunk)
+   ("p" . git-gutter+-previous-hunk)
+   ("s" . git-gutter+-stage-hunks)
+   ("r" . git-gutter+-revert-hunk)))
+```
+   
+
+
 
 ## Modes and interpreters
 

--- a/bind-key.el
+++ b/bind-key.el
@@ -326,6 +326,10 @@ function symbol (unquoted)."
               (and prefix (not prefix-map)))
       (error "Both :prefix-map and :prefix must be supplied"))
 
+    (when repeat-type
+      (unless repeat-map
+        (error ":continue and :exit require specifying :repeat-map")))
+
     (when (and menu-name (not prefix))
       (error "If :menu-name is supplied, :prefix must be too"))
 

--- a/bind-key.el
+++ b/bind-key.el
@@ -257,14 +257,22 @@ Accepts keyword arguments:
                          for these bindings
 :prefix-docstring STR  - docstring for the prefix-map variable
 :menu-name NAME        - optional menu string for prefix map
+:repeat-docstring STR  - docstring for the repeat-map variable
+:repeat-map MAP        - name of the repeat map that should be created
+                         for these bindings. If specified, the
+                         'repeat-map property of each command bound
+                         (within the scope of the :repeat-map keyword)
+                         is set to this map.
 :filter FORM           - optional form to determine when bindings apply
 
 The rest of the arguments are conses of keybinding string and a
 function symbol (unquoted)."
   (let (map
-        doc
+        prefix-doc
         prefix-map
         prefix
+        repeat-map
+        repeat-doc
         filter
         menu-name
         pkg)
@@ -276,11 +284,18 @@ function symbol (unquoted)."
                         (not prefix-map))
                    (setq map (cadr args)))
                   ((eq :prefix-docstring (car args))
-                   (setq doc (cadr args)))
+                   (setq prefix-doc (cadr args)))
                   ((and (eq :prefix-map (car args))
                         (not (memq map '(global-map
                                          override-global-map))))
                    (setq prefix-map (cadr args)))
+                  ((eq :repeat-docstring (car args))
+                   (setq repeat-doc (cadr args)))
+                  ((and (eq :repeat-map (car args))
+                        (not (memq map '(global-map
+                                         override-global-map))))
+                   (setq repeat-map (cadr args))
+                   (setq map repeat-map))
                   ((eq :prefix (car args))
                    (setq prefix (cadr args)))
                   ((eq :filter (car args))
@@ -327,13 +342,16 @@ function symbol (unquoted)."
         (append
          (when prefix-map
            `((defvar ,prefix-map)
-             ,@(when doc `((put ',prefix-map 'variable-documentation ,doc)))
+             ,@(when prefix-doc `((put ',prefix-map 'variable-documentation ,prefix-doc)))
              ,@(if menu-name
                    `((define-prefix-command ',prefix-map nil ,menu-name))
                  `((define-prefix-command ',prefix-map)))
              ,@(if (and map (not (eq map 'global-map)))
                    (wrap map `((bind-key ,prefix ',prefix-map ,map ,filter)))
                  `((bind-key ,prefix ',prefix-map nil ,filter)))))
+         (when repeat-map
+           `((defvar ,repeat-map (make-sparse-keymap)
+               ,@(when repeat-doc `(,repeat-doc)))))
          (wrap map
                (cl-mapcan
                 (lambda (form)
@@ -341,7 +359,11 @@ function symbol (unquoted)."
                     (if prefix-map
                         `((bind-key ,(car form) ,fun ,prefix-map ,filter))
                       (if (and map (not (eq map 'global-map)))
-                          `((bind-key ,(car form) ,fun ,map ,filter))
+                          ;; Only needed in this branch, since when
+                          ;; repeat-map is non-nil, map is always
+                          ;; non-nil
+                          `(,@(when repeat-map `((put ,fun 'repeat-map ',repeat-map)))
+                            (bind-key ,(car form) ,fun ,map ,filter))
                         `((bind-key ,(car form) ,fun nil ,filter))))))
                 first))
          (when next
@@ -361,6 +383,12 @@ Accepts keyword arguments:
                          for these bindings
 :prefix-docstring STR  - docstring for the prefix-map variable
 :menu-name NAME        - optional menu string for prefix map
+:repeat-docstring STR  - docstring for the repeat-map variable
+:repeat-map MAP        - name of the repeat map that should be created
+                         for these bindings. If specified, the
+                         'repeat-map property of each command bound
+                         (within the scope of the :repeat-map keyword)
+                         is set to this map.
 :filter FORM           - optional form to determine when bindings apply
 
 The rest of the arguments are conses of keybinding string and a

--- a/bind-key.el
+++ b/bind-key.el
@@ -266,6 +266,10 @@ Accepts keyword arguments:
 :exit BINDINGS         - Within the scope of :repeat-map will bind the
                          key in the repeat map, but will not set the
                          'repeat-map property of the bound command.
+:continue BINDINGS     - Within the scope of :repeat-map forces the
+                         same behaviour as if no special keyword had
+                         been used (that is, the command is bound, and
+                         it's 'repeat-map property set)
 :filter FORM           - optional form to determine when bindings apply
 
 The rest of the arguments are conses of keybinding string and a
@@ -301,6 +305,9 @@ function symbol (unquoted)."
                                          override-global-map))))
                    (setq repeat-map (cadr args))
                    (setq map repeat-map))
+                  ((eq :continue (car args))
+                   (setq repeat-type :continue
+                         arg-change-func 'cdr))
                   ((eq :exit (car args))
                    (setq repeat-type :exit
                          arg-change-func 'cdr))
@@ -376,9 +383,10 @@ function symbol (unquoted)."
                         `((bind-key ,(car form) ,fun nil ,filter))))))
                 first))
          (when next
-           (bind-keys-form (if pkg
-                               (cons :package (cons pkg next))
-                             next) map)))))))
+           (bind-keys-form `(,@(when repeat-map `(:repeat-map ,repeat-map))
+                             ,@(if pkg
+                                   (cons :package (cons pkg next))
+                                 next)) map)))))))
 
 ;;;###autoload
 (defmacro bind-keys (&rest args)
@@ -401,6 +409,10 @@ Accepts keyword arguments:
 :exit BINDINGS         - Within the scope of :repeat-map will bind the
                          key in the repeat map, but will not set the
                          'repeat-map property of the bound command.
+:continue BINDINGS     - Within the scope of :repeat-map forces the
+                         same behaviour as if no special keyword had
+                         been used (that is, the command is bound, and
+                         it's 'repeat-map property set)
 :filter FORM           - optional form to determine when bindings apply
 
 The rest of the arguments are conses of keybinding string and a

--- a/use-package-bind-key.el
+++ b/use-package-bind-key.el
@@ -86,6 +86,8 @@ deferred until the prefix key sequence is pressed."
          ;;   :prefix-docstring STRING
          ;;   :prefix-map SYMBOL
          ;;   :prefix STRING
+	 ;;   :repeat-docstring STRING
+         ;;   :repeat-map SYMBOL
          ;;   :filter SEXP
          ;;   :menu-name STRING
          ;;   :package SYMBOL
@@ -93,6 +95,8 @@ deferred until the prefix key sequence is pressed."
               (and (eq x :prefix) (stringp (cadr arg)))
               (and (eq x :prefix-map) (symbolp (cadr arg)))
               (and (eq x :prefix-docstring) (stringp (cadr arg)))
+	      (and (eq x :repeat-map) (symbolp (cadr arg)))
+              (and (eq x :repeat-docstring) (stringp (cadr arg)))
               (eq x :filter)
               (and (eq x :menu-name) (stringp (cadr arg)))
               (and (eq x :package) (symbolp (cadr arg))))

--- a/use-package-bind-key.el
+++ b/use-package-bind-key.el
@@ -91,12 +91,13 @@ deferred until the prefix key sequence is pressed."
          ;;   :filter SEXP
          ;;   :menu-name STRING
          ;;   :package SYMBOL
-	 ;;   :exit used within :repeat-map
+	 ;;   :continue and :exit are used within :repeat-map
          ((or (and (eq x :map) (symbolp (cadr arg)))
               (and (eq x :prefix) (stringp (cadr arg)))
               (and (eq x :prefix-map) (symbolp (cadr arg)))
               (and (eq x :prefix-docstring) (stringp (cadr arg)))
 	      (and (eq x :repeat-map) (symbolp (cadr arg)))
+	      (eq x :continue)
 	      (eq x :exit)
               (and (eq x :repeat-docstring) (stringp (cadr arg)))
               (eq x :filter)

--- a/use-package-bind-key.el
+++ b/use-package-bind-key.el
@@ -91,11 +91,13 @@ deferred until the prefix key sequence is pressed."
          ;;   :filter SEXP
          ;;   :menu-name STRING
          ;;   :package SYMBOL
+	 ;;   :exit used within :repeat-map
          ((or (and (eq x :map) (symbolp (cadr arg)))
               (and (eq x :prefix) (stringp (cadr arg)))
               (and (eq x :prefix-map) (symbolp (cadr arg)))
               (and (eq x :prefix-docstring) (stringp (cadr arg)))
 	      (and (eq x :repeat-map) (symbolp (cadr arg)))
+	      (eq x :exit)
               (and (eq x :repeat-docstring) (stringp (cadr arg)))
               (eq x :filter)
               (and (eq x :menu-name) (stringp (cadr arg)))


### PR DESCRIPTION
Add keywords to generate and bind keys in repeat maps, for use with emacs' new `repeat-mode`. Heavily inspired by the syntax of [define-repeat-map.el](https://tildegit.org/acdw/define-repeat-map.el). Fix #964.

It's worth mentioning that I tried to implement an `:enter` keyword as well, which would set the `repeat-map` property of a command, but without binding that command in the keymap. But I discovered that commands like this (with a `repeat-map` property pointing at a keymap in which they are not themselves bound) don't seem to actually invoke the repeat map. I tried it with the standard, manual way of building a repeat map and that didn't work either, so I think this is a bug with repeat-mode (or a feature which I don't understand). `:enter` would probably be the rarest used keyword though, so I don' think this is a big problem, and it would be simple to add in future if need be.