### PR TITLE
Makefile.doc: Rename org-man to ol-man

### DIFF
--- a/Makefile.doc
+++ b/Makefile.doc
@@ -60,7 +60,7 @@ clean:
 # using a shared target.
 
 DOC_ARGS  = --batch -Q $(DOC_LOAD_PATH)
-DOC_ARGS += -l ox-extra -l org-man -l ox-texinfo+.el
+DOC_ARGS += -l ox-extra -l ol-man -l ox-texinfo+.el
 DOC_EVAL  = --eval "(ox-extras-activate '(ignore-headlines))"
 DOC_EVAL += -f org-texinfo-export-to-texinfo
 


### PR DESCRIPTION
It seems like `org-man.el` has been renamed to `ol-man.el` in commit
[453c79a6193d66add56062f2a9788cadff509f7d](https://git.sr.ht/~bzg/org-contrib/commit/453c79a6193d66add56062f2a9788cadff509f7d)
of [org-contrib](https://git.sr.ht/~bzg/org-contrib).

Fixes #980.