### PR TITLE
Quote single quotes in docstrings or use different quoting

### DIFF
--- a/bind-key.el
+++ b/bind-key.el
@@ -160,7 +160,7 @@ For example:
 
   (bind-key \"M-h\" #'some-interactive-function my-mode-map)
 
-  (bind-key \"M-h\" #'some-interactive-function 'my-mode-map)
+  (bind-key \"M-h\" #'some-interactive-function \\='my-mode-map)
 
 If PREDICATE is non-nil, it is a form evaluated to determine when
 a key should be bound. It must return non-nil in such cases.
@@ -262,16 +262,16 @@ Accepts keyword arguments:
 :repeat-docstring STR  - docstring for the repeat-map variable
 :repeat-map MAP        - name of the repeat map that should be created
                          for these bindings. If specified, the
-                         'repeat-map property of each command bound
-                         (within the scope of the :repeat-map keyword)
+                         `repeat-map' property of each command bound
+                         (within the scope of the `:repeat-map' keyword)
                          is set to this map.
-:exit BINDINGS         - Within the scope of :repeat-map will bind the
+:exit BINDINGS         - Within the scope of `:repeat-map' will bind the
                          key in the repeat map, but will not set the
-                         'repeat-map property of the bound command.
-:continue BINDINGS     - Within the scope of :repeat-map forces the
+                         `repeat-map' property of the bound command.
+:continue BINDINGS     - Within the scope of `:repeat-map' forces the
                          same behaviour as if no special keyword had
                          been used (that is, the command is bound, and
-                         it's 'repeat-map property set)
+                         it's `repeat-map' property set)
 :filter FORM           - optional form to determine when bindings apply
 
 The rest of the arguments are conses of keybinding string and a
@@ -409,16 +409,16 @@ Accepts keyword arguments:
 :repeat-docstring STR  - docstring for the repeat-map variable
 :repeat-map MAP        - name of the repeat map that should be created
                          for these bindings. If specified, the
-                         'repeat-map property of each command bound
-                         (within the scope of the :repeat-map keyword)
+                         `repeat-map' property of each command bound
+                         (within the scope of the `:repeat-map' keyword)
                          is set to this map.
-:exit BINDINGS         - Within the scope of :repeat-map will bind the
+:exit BINDINGS         - Within the scope of `:repeat-map' will bind the
                          key in the repeat map, but will not set the
-                         'repeat-map property of the bound command.
-:continue BINDINGS     - Within the scope of :repeat-map forces the
+                         `repeat-map' property of the bound command.
+:continue BINDINGS     - Within the scope of `:repeat-map' forces the
                          same behaviour as if no special keyword had
                          been used (that is, the command is bound, and
-                         it's 'repeat-map property set)
+                         it's `repeat-map' property set)
 :filter FORM           - optional form to determine when bindings apply
 
 The rest of the arguments are conses of keybinding string and a

--- a/use-package-core.el
+++ b/use-package-core.el
@@ -908,12 +908,12 @@ If RECURSED is non-nil, recurse into sublists."
   "A predicate that recognizes functional constructions:
   nil
   sym
-  'sym
+  \\='sym
   (quote sym)
   #'sym
   (function sym)
   (lambda () ...)
-  '(lambda () ...)
+  \\='(lambda () ...)
   (quote (lambda () ...))
   #'(lambda () ...)
   (function (lambda () ...))"

--- a/use-package-ensure.el
+++ b/use-package-ensure.el
@@ -93,7 +93,7 @@ The default value uses package.el to install the package."
 (defun use-package-archive-exists-p (archive)
   "Check if a given ARCHIVE is enabled.
 
-ARCHIVE can be a string or a symbol or 'manual to indicate a
+ARCHIVE can be a string or a symbol or `manual' to indicate a
 manually updated package."
   (if (member archive '(manual "manual"))
       't


### PR DESCRIPTION
The byte-compiler started pointing this out:
  Warning: docstring has wrong usage of unescaped single
  quotes (use \= or different quoting)