### PR TITLE
Make sure that bind-key's `override-global-mode` is initially on

### DIFF
--- a/bind-key.el
+++ b/bind-key.el
@@ -132,7 +132,6 @@
 (define-minor-mode override-global-mode
   "A minor mode so that keymap settings override other modes."
   :init-value t
-  :global t
   :lighter "")
 
 ;; the keymaps in `emulation-mode-map-alists' take precedence over

--- a/bind-key.el
+++ b/bind-key.el
@@ -131,6 +131,7 @@
 
 (define-minor-mode override-global-mode
   "A minor mode so that keymap settings override other modes."
+  :init-value t
   :global t
   :lighter "")
 


### PR DESCRIPTION
In cb90d3f the arguments to `define-minor-mode` were changed
erroneously. Whereas the `override-global-mode` was initially defined
as `(define-minor-mode override-global-mode "..." t "")`, the two
latter arguments where changed to `:global t :lighter ""`. However,
the two original arguments corresponded to the keywords `:init-value`
and `:lighter`, respectively.

With `:init-value t` missing, the minor mode isn't enabled by default,
and `bind-key*` appears not to work (see also #991). This fixes the
issue.

Note that to follow the exact meaning of the original code, one would
also have to remove the `:global t` argument. I don't know if that's
desirable or not, probably not. 