### PR TITLE
Fix emacs native compilation warning

### DIFF
--- a/use-package-core.el
+++ b/use-package-core.el
@@ -910,12 +910,12 @@ If RECURSED is non-nil, recurse into sublists."
   sym
   \\='sym
   (quote sym)
-  #'sym
+  #\\='sym
   (function sym)
   (lambda () ...)
   \\='(lambda () ...)
   (quote (lambda () ...))
-  #'(lambda () ...)
+  #\\='(lambda () ...)
   (function (lambda () ...))"
   (or (if binding
           (symbolp v)
@@ -930,7 +930,7 @@ If RECURSED is non-nil, recurse into sublists."
 (defun use-package-normalize-function (v)
   "Reduce functional constructions to one of two normal forms:
   sym
-  #'(lambda () ...)"
+  #\\='(lambda () ...)"
   (cond ((symbolp v) v)
         ((and (listp v)
               (memq (car v) '(quote function))


### PR DESCRIPTION
```
 ■  Warning (comp): use-package-core.el:907:2: Warning: docstring has
wrong usage of unescaped single quotes (use \= or different quoting)
 ■  Warning (comp): use-package-core.el:930:2: Warning: docstring has
wrong usage of unescaped single quotes (use \= or different quoting)
```

To reproduce, have emacs built with native compilation and notice the compilation logs. You can then open a file and run `M-x emacs-lisp-native-compile-and-load` before and after the changes to see the warning is removed.