### PR TITLE
Native compiler warnings part 2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ jobs:
           - '26.2'
           - '26.3'
           - '27.1'
+          - '27.2'
+          - '28.1'
           - 'snapshot'
         include:
           - emacs_version: 'snapshot'

--- a/Makefile.lisp
+++ b/Makefile.lisp
@@ -19,7 +19,8 @@ lisp:       $(ELCS)
 
 %.elc: %.el
 	@printf "Compiling $<\n"
-	-@$(BATCH) --eval "(progn\
+	@$(BATCH) -q --eval "(progn\
+	(setq byte-compile-error-on-warn t) \
 	(when (file-exists-p \"$@\")\
 	  (delete-file \"$@\"))\
 	(fset 'message* (symbol-function 'message))\

--- a/bind-key.el
+++ b/bind-key.el
@@ -158,9 +158,9 @@ COMMAND must be an interactive function or lambda form.
 KEYMAP, if present, should be a keymap variable or symbol.
 For example:
 
-  (bind-key \"M-h\" #'some-interactive-function my-mode-map)
+  (bind-key \"M-h\" #\\='some-interactive-function my-mode-map)
 
-  (bind-key \"M-h\" #'some-interactive-function \\='my-mode-map)
+  (bind-key \"M-h\" #\\='some-interactive-function \\='my-mode-map)
 
 If PREDICATE is non-nil, it is a form evaluated to determine when
 a key should be bound. It must return non-nil in such cases.


### PR DESCRIPTION
I did not know bind-key was part of this repository, I thought it might be it's own separate package. Otherwise I would have made this change as part of #997 . The CI pipeline is updated now with newer emacs versions, and the compiler make target adds the extra flags/eval to ensure compilation fails if warnigns are present, to ensure this will not pop up again in the future.

To reproduce, have emacs built with native compilation and notice the
compilation logs. You can then open the offending file and run `M-x
emacs-lisp-native-compile-and-load` before and after the changes to see
the warning is removed.

```
 ■  Warning (comp): bind-key.el:150:2: Warning: docstring has wrong
usage of unescaped single quotes (use \= or different quoting)
```