### PR TITLE
fix #934: use face-spec-set instead of custom-set-faces

### DIFF
--- a/use-package-core.el
+++ b/use-package-core.el
@@ -1518,7 +1518,7 @@ no keyword implies `:all'."
 (defun use-package-handler/:custom-face (name _keyword args rest state)
   "Generate use-package custom-face keyword code."
   (use-package-concat
-   (mapcar #'(lambda (def) `(custom-set-faces (backquote ,def))) args)
+   (mapcar #'(lambda (def) `(apply #'face-spec-set (backquote ,def))) args)
    (use-package-process-keywords name rest state)))
 
 ;;;; :init

--- a/use-package-tests.el
+++ b/use-package-tests.el
@@ -1156,7 +1156,7 @@
   (match-expansion
    (use-package foo :custom-face (foo ((t (:background "#e4edfc")))))
    `(progn
-      (custom-set-faces (backquote (foo ((t (:background "#e4edfc"))))))
+      (apply #'face-spec-set (backquote (foo ((t (:background "#e4edfc"))))))
       (require 'foo nil nil))))
 
 (ert-deftest use-package-test/:custom-face-2 ()
@@ -1166,11 +1166,11 @@
      (example-1-face ((t (:foreground "LightPink"))))
      (example-2-face ((t (:foreground "LightGreen")))))
    `(progn
-     (custom-set-faces
-      (backquote (example-1-face ((t (:foreground "LightPink"))))))
-     (custom-set-faces
-      (backquote (example-2-face ((t (:foreground "LightGreen"))))))
-     (require 'example nil nil))))
+      (apply #'face-spec-set
+             (backquote (example-1-face ((t (:foreground "LightPink"))))))
+      (apply #'face-spec-set
+             (backquote (example-2-face ((t (:foreground "LightGreen"))))))
+      (require 'example nil nil))))
 
 (ert-deftest use-package-test/:init-1 ()
   (match-expansion


### PR DESCRIPTION
For reference, each time I press the "apply and save" button when I use Custom, my custom file stores not only the settings I've made but each face specified with the `:custom-face` section in my `use-package` declarations. This PR fixes it, as suggested in #934.