### PR TITLE
fix #1008: allow passing the SPEC-TYPE argument via :custom-face

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,9 +481,9 @@ The `:custom-face` keyword allows customization of package custom faces.
   (eruby-standard-face ((t (:slant italic)))))
 
 (use-package example
-  :custom-face 
+  :custom-face
   (example-1-face ((t (:foreground "LightPink"))))
-  (example-2-face ((t (:foreground "LightGreen")))))
+  (example-2-face ((t (:foreground "LightGreen"))) face-defspec-spec))
 
 (use-package zenburn-theme
   :preface

--- a/use-package-core.el
+++ b/use-package-core.el
@@ -1501,7 +1501,7 @@ no keyword implies `:all'."
 (defun use-package-normalize/:custom-face (name-symbol _keyword arg)
   "Normalize use-package custom-face keyword."
   (let ((error-msg
-         (format "%s wants a (<symbol> <face-spec>) or list of these"
+         (format "%s wants a (<symbol> <face-spec> [spec-type]) or list of these"
                  name-symbol)))
     (unless (listp arg)
       (use-package-error error-msg))
@@ -1512,7 +1512,7 @@ no keyword implies `:all'."
             (spec (nth 1 def)))
         (when (or (not face)
                   (not spec)
-                  (> (length def) 2))
+                  (> (length def) 3))
           (use-package-error error-msg))))))
 
 (defun use-package-handler/:custom-face (name _keyword args rest state)

--- a/use-package-tests.el
+++ b/use-package-tests.el
@@ -1172,6 +1172,13 @@
              (backquote (example-2-face ((t (:foreground "LightGreen"))))))
       (require 'example nil nil))))
 
+(ert-deftest use-package-test/:custom-face-3 ()
+  (match-expansion
+   (use-package foo :custom-face (foo ((t (:background "#e4edfc"))) face-defspec-spec))
+   `(progn
+      (apply #'face-spec-set (backquote (foo ((t (:background "#e4edfc"))) face-defspec-spec)))
+      (require 'foo nil nil))))
+
 (ert-deftest use-package-test/:init-1 ()
   (match-expansion
    (use-package foo :init (init))

--- a/use-package.el
+++ b/use-package.el
@@ -6,7 +6,7 @@
 ;; Maintainer: John Wiegley <johnw@newartisans.com>
 ;; Created: 17 Jun 2012
 ;; Modified: 29 Nov 2017
-;; Version: 2.4.2
+;; Version: 2.4.3
 ;; Package-Requires: ((emacs "24.3") (bind-key "2.4"))
 ;; Keywords: dotemacs startup speed config package
 ;; URL: https://github.com/jwiegley/use-package


### PR DESCRIPTION
This allows passing the `spec-type` argument to `face-spec-set`. Fixes #1008