### PR TITLE
Recommend GNU ELPA over MELPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![Join the chat at https://gitter.im/use-package/Lobby](https://badges.gitter.im/use-package/Lobby.svg)](https://gitter.im/use-package/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://github.com/jwiegley/use-package/actions/workflows/test.yml/badge.svg)](https://github.com/jwiegley/use-package/actions)
-[![MELPA](https://melpa.org/packages/use-package-badge.svg)](https://melpa.org/#/use-package)
-[![MELPA Stable](https://stable.melpa.org/packages/use-package-badge.svg)](https://stable.melpa.org/#/use-package)
+[![GNU ELPA](https://elpa.gnu.org/packages/use-package.svg)](https://elpa.gnu.org/packages/use-package.html)
 
 The `use-package` macro allows you to isolate package configuration in your
 `.emacs` file in a way that is both performance-oriented and, well, tidy.  I
@@ -60,7 +59,7 @@ and loading of packages.
 ## Installing use-package
 
 Either clone from this GitHub repository or install from
-[MELPA](https://melpa.org/) (recommended).
+[GNU ELPA](https://elpa.gnu.org/) (recommended).
 
 ## Getting started
 
@@ -876,7 +875,7 @@ like
 Lastly, when running on Emacs 24.4 or later, use-package can pin a package to
 a specific archive, allowing you to mix and match packages from different
 archives.  The primary use-case for this is preferring packages from the
-`melpa-stable` and `gnu` archives, but using specific packages from `melpa`
+`gnu` and `melpa-stable` archives, but using specific packages from `melpa`
 when you need to track newer versions than what is available in the `stable`
 archives is also a valid use-case.
 
@@ -903,7 +902,7 @@ Example:
 ``` elisp
 (use-package company
   :ensure t
-  :pin melpa-stable)
+  :pin gnu)
 
 (use-package evil
   :ensure t)

--- a/use-package.texi
+++ b/use-package.texi
@@ -67,7 +67,7 @@ around 2 seconds, with no loss of functionality!
 
 Installation
 
-* Installing from an Elpa Archive::
+* Installing from GNU ELPA::
 * Installing from the Git Repository::
 * Post-Installation Tasks::
 
@@ -119,50 +119,27 @@ use-package can be installed using Emacs' package manager or manually from
 its development repository.
 
 @menu
-* Installing from an Elpa Archive::
+* Installing from GNU ELPA::
 * Installing from the Git Repository::
 * Post-Installation Tasks::
 @end menu
 
-@node Installing from an Elpa Archive
-@section Installing from an Elpa Archive
+@node Installing from GNU ELPA
+@section Installing from GNU ELPA
 
-use-package is available from Melpa and Melpa-Stable. If you haven't used
-Emacs' package manager before, then it is high time you familiarize yourself
+use-package is available from GNU ELPA.  If you haven't used Emacs'
+package manager before, then it is high time you familiarize yourself
 with it by reading the documentation in the Emacs manual, see
-@ref{Packages,,,emacs,}. Then add one of the archives to @code{package-archives}:
+@ref{Packages,,,emacs,}.
 
-@itemize
-@item
-To use Melpa:
-@end itemize
-
-@lisp
-(require 'package)
-(add-to-list 'package-archives
-             '("melpa" . "https://melpa.org/packages/") t)
-@end lisp
-
-@itemize
-@item
-To use Melpa-Stable:
-@end itemize
-
-@lisp
-(require 'package)
-(add-to-list 'package-archives
-             '("melpa-stable" . "https://stable.melpa.org/packages/") t)
-@end lisp
-
-Once you have added your preferred archive, you need to update the
-local package list using:
+First, you need to update the local package list using:
 
 @example
 M-x package-refresh-contents RET
 @end example
 
-Once you have done that, you can install use-package and its dependencies
-using:
+Once you have done that, you can install use-package and its
+dependencies using:
 
 @example
 M-x package-install RET use-package RET


### PR DESCRIPTION
This changes `README.md` to recommend GNU ELPA over the one in MELPA.