### PR TITLE
Ignore LICENSE in .elpaignore

### DIFF
--- a/.elpaignore
+++ b/.elpaignore
@@ -1,1 +1,1 @@
-doc/*
+LICENSE


### PR DESCRIPTION
We generally prefer not to include the `LICENSE` file in the GNU ELPA tarball, as it contributes to the file size for little benefit. We also no longer need to ignore `doc/`.