### PR TITLE
Add .dir-locals.el

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,8 @@
+;;; Directory Local Variables         -*- no-byte-compile: t; -*-
+;;; For more information see (info "(emacs) Directory Variables")
+
+((nil . ((sentence-end-double-space . t)
+         (emacs-lisp-docstring-fill-column . 65)
+         (fill-column . 70)))
+ (emacs-lisp-mode . ((indent-tabs-mode . nil)))
+ (lisp-data-mode . ((indent-tabs-mode . nil))))

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /doc/content/*
 /stats/
 /use-package/
+.dir-locals-2.el

--- a/bind-key.el
+++ b/bind-key.el
@@ -542,7 +542,6 @@ function symbol (unquoted)."
 
 ;; Local Variables:
 ;; outline-regexp: ";;;\\(;* [^\s\t\n]\\|###autoload\\)\\|("
-;; indent-tabs-mode: nil
 ;; End:
 
 ;;; bind-key.el ends here

--- a/use-package-chords-tests.el
+++ b/use-package-chords-tests.el
@@ -153,7 +153,6 @@
             '(bind-chord "C-u" #'key3 my-map2)))))))
 
 ;; Local Variables:
-;; indent-tabs-mode: nil
 ;; no-byte-compile: t
 ;; no-update-autoloads: t
 ;; End:

--- a/use-package-core.el
+++ b/use-package-core.el
@@ -1721,8 +1721,4 @@ this file.  Usage:
 
 (provide 'use-package-core)
 
-;; Local Variables:
-;; indent-tabs-mode: nil
-;; End:
-
 ;;; use-package-core.el ends here

--- a/use-package-tests.el
+++ b/use-package-tests.el
@@ -1986,7 +1986,6 @@
     (should (eq (nth 2 binding) nil))))
 
 ;; Local Variables:
-;; indent-tabs-mode: nil
 ;; no-byte-compile: t
 ;; no-update-autoloads: t
 ;; End:


### PR DESCRIPTION
This replaces some local variables with a `.dir-locals.el` file using some of the same customizations as in the main Emacs repository.