### PR TITLE
Add package requires for bind-key.el and bind-chord.el

### DIFF
--- a/bind-chord.el
+++ b/bind-chord.el
@@ -6,7 +6,7 @@
 ;; Keywords: convenience, tools, extensions
 ;; URL: https://github.com/jwiegley/use-package
 ;; Version: 0.2.1
-;; Package-Requires: ((bind-key "1.0") (key-chord "0.6"))
+;; Package-Requires: ((emacs "24.3") (bind-key "1.0") (key-chord "0.6"))
 ;; Filename: bind-chord.el
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/bind-key.el
+++ b/bind-key.el
@@ -7,7 +7,7 @@
 ;; Created: 16 Jun 2012
 ;; Version: 2.4.1
 ;; Package-Requires: ((emacs "24.3"))
-;; Keywords: keys keybinding config dotemacs
+;; Keywords: keys keybinding config dotemacs extensions
 ;; URL: https://github.com/jwiegley/use-package
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/bind-key.el
+++ b/bind-key.el
@@ -6,6 +6,7 @@
 ;; Maintainer: John Wiegley <johnw@newartisans.com>
 ;; Created: 16 Jun 2012
 ;; Version: 2.4.1
+;; Package-Requires: ((emacs "24.3"))
 ;; Keywords: keys keybinding config dotemacs
 ;; URL: https://github.com/jwiegley/use-package
 
@@ -516,8 +517,7 @@ function symbol (unquoted)."
                (command-desc (get-binding-description command))
                (was-command-desc (and was-command
                                       (get-binding-description was-command)))
-               (at-present-desc (get-binding-description at-present))
-               )
+               (at-present-desc (get-binding-description at-present)))
           (let ((line
                  (format
                   (format "%%-%ds%%-%ds%%s\n" (car bind-key-column-widths)

--- a/use-package.el
+++ b/use-package.el
@@ -7,7 +7,7 @@
 ;; Created: 17 Jun 2012
 ;; Version: 2.4.4
 ;; Package-Requires: ((emacs "24.3") (bind-key "2.4"))
-;; Keywords: dotemacs startup speed config package
+;; Keywords: dotemacs startup speed config package extensions
 ;; URL: https://github.com/jwiegley/use-package
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
The `bind-key.el` and `bind-chord.el` were missing the `Package-Requires` header.

Also add in a known keyword from `finder-known-keywords` while we're at it.

These issues were found using `package-lint`.