### PR TITLE
Remove tests lacking a copyright assignment for now

### DIFF
--- a/use-package-tests.el
+++ b/use-package-tests.el
@@ -1505,37 +1505,6 @@
              (config)
              t))))))
 
-(ert-deftest use-package-test/pre-post-hooks-with-:config ()
-  (let ((use-package-inject-hooks t))
-    (match-expansion
-     (use-package foo :config (config))
-     `(progn
-       (when
-           (run-hook-with-args-until-failure 'use-package--foo--pre-init-hook)
-         (run-hooks 'use-package--foo--post-init-hook))
-       (require 'foo nil nil)
-       (when
-           (run-hook-with-args-until-failure 'use-package--foo--pre-config-hook)
-         (config)
-         (run-hooks 'use-package--foo--post-config-hook))
-       t))))
-
-(ert-deftest use-package-test/pre-post-hooks-without-:config ()
-  ;; https://github.com/jwiegley/use-package/issues/785
-  (let ((use-package-inject-hooks t))
-    (match-expansion
-     (use-package foo)
-     `(progn
-        (when
-            (run-hook-with-args-until-failure 'use-package--foo--pre-init-hook)
-          (run-hooks 'use-package--foo--post-init-hook))
-        (require 'foo nil nil)
-        (when
-            (run-hook-with-args-until-failure 'use-package--foo--pre-config-hook)
-          t
-          (run-hooks 'use-package--foo--post-config-hook))
-        t))))
-
 (ert-deftest use-package-test-normalize/:diminish ()
   (should (equal (use-package-normalize-diminish 'foopkg :diminish nil)
                  '(foopkg-mode)))


### PR DESCRIPTION
We are still lacking a copyright assignment for @jjlee, which is blocking the merge of `use-package` into Emacs. If we remove these tests, the total number of lines added by him will be under the limit, and we can merge this. See issue #840 and #282.

I have asked @jjlee to sign the papers, and once that is done we can add the tests again (probably to the main Emacs repository).

@jwiegley What do you think?