### PR TITLE
Allow defining a key sequence using a cons with `:bind`

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,21 @@ The `:bind` keyword takes either a cons or a list of conses:
          ("M-o w" . highlight-phrase)))
 ```
 
-The `:commands` keyword likewise takes either a symbol or a list of symbols.
+Alternatively, the command name may be replaced with a cons `(desc . command)`,
+where `desc` is a string describing `command`, which is the name of a command
+to bind to:
+
+```elisp
+(use-package avy
+  :bind ("C-:" ("Jump to char" . avy-goto-char)
+         "M-g f" ("Jump to line" . avy-goto-line)))
+```
+
+These descriptions can be used by other code that deals with key bindings.
+For example, the GNU ELPA package which-key displays them when showing key
+bindings, instead of the plain command names.
+
+The `:commands` keyword takes either a symbol or a list of symbols.
 
 **NOTE**: inside strings, special keys like `tab` or `F1`-`Fn` have to be written inside angle brackets, e.g. `"C-<up>"`.
 Standalone special keys (and some combinations) can be written in square brackets, e.g. `[tab]` instead of `"<tab>"`. The syntax for the keybindings is similar to

--- a/bind-key.el
+++ b/bind-key.el
@@ -166,7 +166,8 @@ KEY-NAME may be a vector, in which case it is passed straight to
 spelled-out keystrokes, e.g., \"C-c C-z\".  See the documentation
 of `edmacro-mode' for details.
 
-COMMAND must be an interactive function or lambda form.
+COMMAND must be an interactive function, lambda form, or a cons
+`(STRING . DEFN)'.
 
 KEYMAP, if present, should be a keymap variable or symbol.
 For example:

--- a/use-package-bind-key.el
+++ b/use-package-bind-key.el
@@ -69,8 +69,17 @@ deferred until the prefix key sequence is pressed."
   (let ((arg args)
         args*)
     (while arg
-      (let ((x (car arg)))
+      (let ((x (car arg))
+            (y (cadr arg)))
         (cond
+         ;; (KEY DESC . COMMAND), i.e. (KEY . (DESC . COMMAND))
+         ((and (or (stringp x)
+                   (vectorp x))
+               (consp y)
+               (stringp (car y))
+               (or (use-package-recognize-function (cdr y) t #'stringp)))
+          (setq args* (nconc args* (list (cons x y))))
+          (setq arg (cddr arg)))
          ;; (KEY . COMMAND)
          ((and (consp x)
                (or (stringp (car x))

--- a/use-package-core.el
+++ b/use-package-core.el
@@ -963,10 +963,18 @@ If RECURSED is non-nil, recurse into sublists."
 
 (defun use-package-autoloads-mode (_name _keyword args)
   (mapcar
-   #'(lambda (x) (cons (cdr x) 'command))
+   #'(lambda (x)
+       (cond
+        ((consp (cdr x))
+         (cons (cddr x) 'command))
+        ((consp x)
+         (cons (cdr x) 'command))))
    (cl-remove-if-not #'(lambda (x)
-                         (and (consp x)
-                              (use-package-non-nil-symbolp (cdr x))))
+                         (or (and (consp x)
+                                  (use-package-non-nil-symbolp (cdr x)))
+                             (and (consp x)
+                                  (consp (cdr x))
+                                  (use-package-non-nil-symbolp (cddr x)))))
                      args)))
 
 (defun use-package-handle-mode (name alist args rest state)

--- a/use-package-tests.el
+++ b/use-package-tests.el
@@ -575,7 +575,7 @@
 
 (ert-deftest use-package-test/:bind-1 ()
   (match-expansion
-   (use-package foo :bind ("C-k" . key1) ("C-u" . key2))
+   (use-package foo :bind ("C-k" . key1) ("C-u" ("Key 2" . key2)))
    `(progn
       (unless
           (fboundp 'key1)
@@ -585,11 +585,11 @@
         (autoload #'key2 "foo" nil t))
       (bind-keys :package foo
                  ("C-k" . key1)
-                 ("C-u" . key2)))))
+                 ("C-u" "Key 2" . key2)))))
 
 (ert-deftest use-package-test/:bind-2 ()
   (match-expansion
-   (use-package foo :bind (("C-k" . key1) ("C-u" . key2)))
+   (use-package foo :bind (("C-k" . key1) ("C-u" ("Key 2" . key2))))
    `(progn
       (unless (fboundp 'key1)
         (autoload #'key1 "foo" nil t))
@@ -597,7 +597,7 @@
         (autoload #'key2 "foo" nil t))
       (bind-keys :package foo
                  ("C-k" . key1)
-                 ("C-u" . key2)))))
+                 ("C-u" "Key 2" . key2)))))
 
 (ert-deftest use-package-test/:bind-3 ()
   (match-expansion

--- a/use-package.texi
+++ b/use-package.texi
@@ -763,13 +763,16 @@ can simplify this using the @code{:bind} keyword.
 @subsection Global keybindings
 
 @findex :bind
-To bind keys globally, the @code{:bind} keyword takes either a single
-cons or a list of conses.  Every cons has the form @code{(@var{key}
-. @var{command}}, where @var{key} is a string indicating the key to
-bind, and @var{command} is the name of a command (a symbol).  The
-syntax for the keys is similar to the syntax used by the @code{kbd}
-function (@pxref{Init Rebinding,,, emacs, GNU Emacs Manual} for more
-information).
+To bind keys globally, the @code{:bind} keyword takes as its argument
+either a single cons or a list of conses.  Each cons has the form
+@w{@code{(@var{key} . @var{definition})}}, where @var{key} is a string
+indicating the key to bind, and @var{definition} is the name of a
+command (a symbol).  Alternatively, @var{definition} may be a cons
+@w{@code{(@var{desc} . @var{command})}}, where @var{desc} is a string
+describing @var{command}, which is the name of a command to bind
+@var{key} to.  The syntax for the keys is similar to the syntax used
+by the @code{kbd} function (see @ref{Init Rebinding,,, emacs, GNU
+Emacs Manual}, for more information).
 
 @subheading Using @code{:bind} with a single cons
 
@@ -812,6 +815,27 @@ Examples:
          ([f10] . helm-buffers-list)
          ([S-f10] . helm-recentf)))
 @end lisp
+
+@subheading Providing custom descriptions of commands
+
+When binding keys to commands with @code{:bind}, custom descriptions
+of the commands may optionally be provided.
+
+Examples:
+
+@lisp
+@group
+(use-package avy
+  :bind ("C-:" ("Jump to char" . avy-goto-char)
+         "M-g f" ("Jump to line" . avy-goto-line)))
+@end group
+@end lisp
+
+@noindent
+These descriptions can be used by other code that deals with key
+bindings.  For example, the @acronym{GNU} @acronym{ELPA} package
+@file{which-key} displays them when showing key bindings, instead of
+the plain command names.
 
 @subheading Remapping commands
 


### PR DESCRIPTION
As pointed out in #967, `:bind` does currently not allow defining a key sequence using a cons – `(STRING . DEFN)` – as definition. Consequently, it is not possible to provide a custom description of the command, which e.g. the `which-key` package uses in its hints. This changeset is intended to enable such definitions.

I am new to both Emacs Lisp and the `use-package` code, so the current changes are probably best considered a proof of concept; I expect several changes need be made before merging. I would be grateful for suggestions on how to improve the implementation to the point where it can be merged.

## TODO

- [x] Request assignment form
- [x] Move changes to emacs.git:
  - https://github.com/emacs-mirror/emacs/compare/master...joelpet:emacs:use-package-bind-desc-cons
- [x] Clean up history (probably squash into single commit)
- [x] Complete FSF copyright assignment process
- [x] Add/update docs