### PR TITLE
Allow multiple keymaps in :map argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,14 @@ The effect of this statement is to wait until `helm` has loaded, and then to
 bind the key `C-c h` to `helm-execute-persistent-action` within Helm's local
 keymap, `helm-command-map`.
 
+Multiple keymaps can be specified as a list:
+
+``` elisp
+(use-package helm
+  :bind (:map (lisp-mode-map emacs-lisp-mode-map)
+         ("C-c x" . eval-print-last-sexp)))
+```
+
 Multiple uses of `:map` may be specified. Any binding occurring before the
 first use of `:map` are applied to the global keymap:
 

--- a/bind-chord.el
+++ b/bind-chord.el
@@ -102,7 +102,8 @@ function symbol (unquoted)."
   "Bind multiple chords at once.
 
 Accepts keyword argument:
-:map - a keymap into which the keybindings should be added
+:map - a keymap or list of keymaps into which the keybindings should be
+       added
 
 The rest of the arguments are conses of keybinding string and a
 function symbol (unquoted)."

--- a/use-package-bind-key.el
+++ b/use-package-bind-key.el
@@ -92,19 +92,20 @@ deferred until the prefix key sequence is pressed."
          ;;   :prefix-docstring STRING
          ;;   :prefix-map SYMBOL
          ;;   :prefix STRING
-	 ;;   :repeat-docstring STRING
+         ;;   :repeat-docstring STRING
          ;;   :repeat-map SYMBOL
          ;;   :filter SEXP
          ;;   :menu-name STRING
          ;;   :package SYMBOL
-	 ;;   :continue and :exit are used within :repeat-map
-         ((or (and (eq x :map) (symbolp (cadr arg)))
+         ;;   :continue and :exit are used within :repeat-map
+         ((or (and (eq x :map) (or (symbolp (cadr arg))
+                                   (listp (cadr arg))))
               (and (eq x :prefix) (stringp (cadr arg)))
               (and (eq x :prefix-map) (symbolp (cadr arg)))
               (and (eq x :prefix-docstring) (stringp (cadr arg)))
-	      (and (eq x :repeat-map) (symbolp (cadr arg)))
-	      (eq x :continue)
-	      (eq x :exit)
+              (and (eq x :repeat-map) (symbolp (cadr arg)))
+              (eq x :continue)
+              (eq x :exit)
               (and (eq x :repeat-docstring) (stringp (cadr arg)))
               (eq x :filter)
               (and (eq x :menu-name) (stringp (cadr arg)))

--- a/use-package.texi
+++ b/use-package.texi
@@ -906,6 +906,14 @@ and then to bind the key @code{C-c h} to
 @code{helm-execute-persistent-action} within Helm's local keymap,
 @code{helm-command-map}.
 
+Multiple keymaps can be specified as a list:
+
+@lisp
+(use-package helm
+  :bind (:map (lisp-mode-map emacs-lisp-mode-map)
+         ("C-c x" . eval-print-last-sexp)))
+@end lisp
+
 Multiple uses of @code{:map} may be specified. Any binding occurring
 before the first use of @code{:map} are applied to the global keymap:
 


### PR DESCRIPTION
This is a reimplementation of #830, released as #1019 but reverted due to lacking copyright assignment. The copyright issue should now be solved as I have signed the Emacs copyright papers.

Sorry for the trouble of requesting a second review. I felt a rewrite was warranted due to discovered loose ends as well as readability.

Noteworthy changes:

- `:map nil`, which currently causes an error, is now treated as synonymous with `:map global-map`.

- `nil`, `global-map`, and `override-global-map` are explicitly disallowed as arguments for `:prefix-map` or `:repeat-map`. Existing checks [here](https://github.com/jwiegley/use-package/compare/master...fishyfriend:maps3?expand=1#diff-4bf2204d9f3a58d301a6b4c1c4efb86a004a3af832ba69eac91d72d94090f506L314) and [here](https://github.com/jwiegley/use-package/compare/master...fishyfriend:maps3?expand=1#diff-4bf2204d9f3a58d301a6b4c1c4efb86a004a3af832ba69eac91d72d94090f506L320) may have been intended for this purpose (perhaps mistakenly substituting `map` for `(cadr args)`?). These checks had simply been removed in the original PR as I couldn't make sense of them.

- A redundant [check](https://github.com/jwiegley/use-package/compare/master...fishyfriend:maps3?expand=1#diff-4bf2204d9f3a58d301a6b4c1c4efb86a004a3af832ba69eac91d72d94090f506L396) related to repeat maps has been removed

## Original description from #830

This PR augments bind-keys to support passing a list of keymaps as the `:map` argument.

When one wants to bind the same key/command pair in multiple keymaps, the current options have some drawbacks:

```elisp
;; Option 1: Code duplication, problematic when duplicated keybindings are numerous
(use-package foopkg
   :bind (:map bar-mode-map
          ("C-c x" . foocmd1)
          ("C-c y" . foocmd2)
          :map baz-mode-map
          ("C-c x" . foocmd1)
          ("C-c y" . foocmd2)))

;; Option 2: Use a loop, sacrificing the convenience and readability of :bind
(use-package foopkg
  :commands (foocmd1 foocmd2)
  :init
  (dolist (map (list bar-mode-map baz-mode-map))
    (bind-keys :map map
               ("C-c x" . foocmd1)
               ("C-c y" . foocmd2))))
```

With the new way, it is possible to avoid duplication and still use `:bind`:

```elisp
(use-package foopkg
  :bind (:map (bar-mode-map baz-mode-map)
        ("C-c x" . foocmd1)
        ("C-c y" . foocmd2)))
```

Additionally this PR clarifies the documentation of `bind-chords` to reflect that this style is already available for that command.

-----

Thanks,
Jacob